### PR TITLE
Fix: 枚举定义问题

### DIFF
--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -1,5 +1,5 @@
 /** 邮箱后缀类型（发起邮箱验证用）：0 -> @m.fudan.edu.cn；1 -> @fudan.edu.cn */
-export const EMAIL_SUFFIX_TYPE = { MOBILE: 0, DESKTOP: 1 } as const;
+export const EMAIL_SUFFIX_TYPE = { M_FUDAN: 0, FUDAN: 1 } as const;
 export const EMAIL_SUFFIX_LABELS: Record<number, string> = {
   0: '@m.fudan.edu.cn',
   1: '@fudan.edu.cn',

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -1,5 +1,4 @@
 export { UserServices } from './UserServices';
-export type { EmailSuffixType } from '@/types/user';
 export type {
   ConfirmEmailVerifyRequest,
   GetUserInfoResponse,

--- a/src/services/User/index.type.ts
+++ b/src/services/User/index.type.ts
@@ -1,5 +1,3 @@
-import type { EmailSuffixType } from '@/types/user';
-
 /** 确认邮箱验证请求参数 */
 export interface ConfirmEmailVerifyRequest {
   token: string;
@@ -8,7 +6,7 @@ export interface ConfirmEmailVerifyRequest {
 /** 发起邮箱验证请求参数 */
 export interface SendEmailVerifyRequest {
   /** 0 -> @m.fudan.edu.cn；1 -> @fudan.edu.cn */
-  suffixType: EmailSuffixType;
+  suffixType: number;
 }
 
 /** 更新用户档案请求参数（仅基本档案可编辑字段） */

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,3 @@
-/** 邮箱后缀类型：0 -> @m.fudan.edu.cn；1 -> @fudan.edu.cn */
-export type EmailSuffixType = 0 | 1;
-
 // 只存储需要的用户字段
 export interface User {
   id: number;

--- a/src/views/group/MyGroup.tsx
+++ b/src/views/group/MyGroup.tsx
@@ -20,7 +20,7 @@ const MyGroup: React.FC = () => {
   const [joinGroupModalOpen, setJoinGroupModalOpen] = useState(false);
   const [createGroupModalOpen, setCreateGroupModalOpen] = useState(false);
 
-  const relationType = RELATION_TYPE_MAP[activeTab] ?? 2;
+  const relationType = RELATION_TYPE_MAP[activeTab] ?? RELATION_TYPE_MAP.joined;
 
   const fetchGroups = useCallback(async () => {
     setLoading(true);

--- a/src/views/profile/Account.tsx
+++ b/src/views/profile/Account.tsx
@@ -134,7 +134,7 @@ const Account: React.FC = () => {
   };
 
   const handleVerify = () => {
-    verifyForm.setFieldsValue({ suffixType: EMAIL_SUFFIX_TYPE.MOBILE });
+    verifyForm.setFieldsValue({ suffixType: EMAIL_SUFFIX_TYPE.M_FUDAN });
     setVerifyModalOpen(true);
   };
 


### PR DESCRIPTION
- 规范化邮箱后缀定义
- 去除magic number ‘2’， 改用字面量属性，增加可读性