### PR TITLE
feat(sidebar): 持久化文档预览位置并统一侧栏文件打开交互

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { Menu } from 'antd';
 import { useNavigate, useLocation } from 'react-router-dom';
 import clsx from 'clsx';
@@ -9,6 +9,7 @@ import {
   RiFileTextLine,
   RiGroupFill,
   RiPenNibFill,
+  RiCloseLine,
 } from 'react-icons/ri';
 
 import FileTypeIcon from '@/components/Common/FileTypeIcon';
@@ -18,70 +19,120 @@ import logoImg from '@/assets/images/logo-icon.png';
 import UserProfile from '@/components/UserProfile';
 import { useRecentFilesStore } from '@/store';
 import { useClickFile } from '@/hooks/drive';
-
-interface SidebarProps {
-  collapsed: boolean;
-  onToggle: () => void;
-}
+import { useAppMessage } from '@/hooks/useAppMessage';
+import { type SidebarProps, type SidebarMenuItem } from './index.type';
 
 const Sidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const recentItems = useRecentFilesStore((s) => s.items);
+  const removeRecentFile = useRecentFilesStore((s) => s.removeFile);
   const clickFile = useClickFile();
+  const messageApi = useAppMessage();
+
+  const handleOpenFile = useCallback(
+    (resourceId: string) => {
+      const found = recentItems.find((i) => i.resourceId === resourceId);
+      if (found) {
+        clickFile({
+          resourceId: found.resourceId,
+          resourceName: found.resourceName,
+          resourceType: found.resourceType,
+        });
+      } else {
+        messageApi.warning('文件不存在或已失效');
+      }
+    },
+    [clickFile, recentItems, messageApi]
+  );
 
   const menuItems = useMemo(() => {
-    const baseItems: Parameters<typeof Menu>[0]['items'] = [
+    const baseItems: SidebarMenuItem[] = [
       {
         key: 'new-chat',
         icon: <RiAddCircleFill size={18} />,
         label: '新聊天',
-        onClick: () => console.log('Create New Chat'),
       },
       {
         key: '/app/note',
         icon: <RiPenNibFill size={18} />,
         label: '新建笔记',
+        onClick: () => navigate('/app/note'),
       },
       {
         key: '/app/drive',
         icon: <RiFileTextLine size={18} />,
         label: '文档与云盘',
+        onClick: () => navigate('/app/drive'),
       },
       {
         key: '/app/my-group',
         icon: <RiGroupFill size={18} />,
         label: '我的小组',
+        onClick: () => navigate('/app/my-group'),
       },
     ];
 
+    // 构造聊天记录列表
     if (!collapsed) {
+      const sessionHistoryChildren: SidebarMenuItem[] = [
+        // 待接入真实记录
+        {
+          key: 'empty-session',
+          label: '暂无会话',
+          disabled: true,
+        },
+      ];
       baseItems.push({
         type: 'group',
         label: '聊天记录',
-        key: 'grp1',
-        children: [{ key: 'history1', label: '暂无会话', disabled: true }],
+        key: 'recent-session',
+        children: sessionHistoryChildren,
       });
 
-      const recentChildren =
+      // 构造最近文件列表
+      const recentFileChildren: SidebarMenuItem[] =
         recentItems.length > 0
           ? recentItems.map((item) => ({
-              key: `recent-${item.resourceId}`,
+              key: `opened-file-${item.resourceId}`,
               icon: <FileTypeIcon resourceType={item.resourceType} size={16} />,
-              label: item.resourceName || '未命名',
+              label: (
+                <div className={styles.fileMenuLabel}>
+                  <span className={styles.fileMenuLabelText}>{item.resourceName || '未命名'}</span>
+                  <button
+                    type="button"
+                    className={styles.fileCloseBtn}
+                    aria-label={`关闭 ${item.resourceName || '未命名'}`}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      removeRecentFile(item.resourceId);
+                    }}
+                  >
+                    <RiCloseLine size={14} />
+                  </button>
+                </div>
+              ),
+              onClick: () => handleOpenFile(item.resourceId),
             }))
-          : [{ key: 'recent-empty', label: '暂无最近文件', disabled: true }];
+          : [
+              {
+                key: 'empty-file',
+                label: '暂无打开的文件',
+                disabled: true,
+              },
+            ];
 
       baseItems.push({
         type: 'group',
-        label: '最近使用',
-        key: 'recent',
-        children: recentChildren,
+        label: '打开的文件',
+        key: 'opened-file',
+        children: recentFileChildren,
       });
     }
 
     return baseItems;
-  }, [collapsed, recentItems]);
+  }, [collapsed, recentItems, handleOpenFile, removeRecentFile, navigate]);
 
   return (
     <div className={clsx(styles.sider, collapsed && styles.collapsed)}>
@@ -108,23 +159,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, onToggle }) => {
           theme="light"
           selectedKeys={[location.pathname]}
           inlineCollapsed={collapsed}
-          items={menuItems as any}
-          onClick={({ key }) => {
-            const k = key.toString();
-            if (k.startsWith('/')) {
-              navigate(k);
-            } else if (k.startsWith('recent-') && k !== 'recent-empty') {
-              const resourceId = k.replace('recent-', '');
-              const item = recentItems.find((i) => i.resourceId === resourceId);
-              if (item) {
-                clickFile({
-                  resourceId: item.resourceId,
-                  resourceName: item.resourceName,
-                  resourceType: item.resourceType,
-                });
-              }
-            }
-          }}
+          items={menuItems}
         />
       </div>
 

--- a/src/components/Sidebar/index.type.ts
+++ b/src/components/Sidebar/index.type.ts
@@ -1,0 +1,9 @@
+import type { MenuProps } from 'antd';
+
+export interface SidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+/** 与 antd Menu items 兼容的侧栏菜单项 */
+export type SidebarMenuItem = NonNullable<MenuProps['items']>[number];

--- a/src/components/Sidebar/style.module.less
+++ b/src/components/Sidebar/style.module.less
@@ -100,3 +100,42 @@
     border-inline-end: none !important;
   }
 }
+
+.fileMenuLabel {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fileMenuLabelText {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fileCloseBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: var(--ant-color-text-tertiary);
+  border-radius: var(--ant-border-radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: var(--ant-color-text);
+    background: var(--ant-color-fill-tertiary);
+  }
+}
+
+:global(.ant-menu-item:hover) .fileCloseBtn {
+  opacity: 1;
+}

--- a/src/hooks/useClickFile.ts
+++ b/src/hooks/useClickFile.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { ResourceItem } from '@/types/resource';
-import { useRecentFilesStore } from '@/store';
+import { usePdfPreviewProgressStore, useRecentFilesStore } from '@/store';
 
 /**
  * 根据资源类型：NOTE 跳转笔记编辑器，其他类型跳转站内 PDF 预览（/app/pdf/:resourceId）
@@ -23,7 +23,15 @@ export const useClickFile = () => {
       if (resourceType === 'NOTE') {
         navigate(`/app/note/${resourceId}`);
       } else {
-        navigate(`/app/pdf/${encodeURIComponent(resourceId)}`);
+        // 尝试恢复上次的阅读状态
+        const progress = usePdfPreviewProgressStore.getState().progressByResourceId[resourceId];
+        const qs = new URLSearchParams();
+        if (progress != null) {
+          qs.set('page', String(progress.page));
+          qs.set('zoom', progress.zoom);
+        }
+        const basePath = `/app/pdf/${encodeURIComponent(resourceId)}`;
+        navigate(qs.size > 0 ? `${basePath}?${qs.toString()}` : basePath);
       }
     },
     [navigate, addFile]

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,8 +9,10 @@
 export {
   useDrivePreferencesStore,
   usePendingVerifyEmailStore,
+  usePdfPreviewProgressStore,
   useRecentFilesStore,
   type DriveViewMode,
+  type PdfPreviewProgress,
   type RecentFileItem,
 } from './zustand';
 

--- a/src/store/zustand/index.ts
+++ b/src/store/zustand/index.ts
@@ -4,4 +4,5 @@
 
 export { useDrivePreferencesStore, type DriveViewMode } from './useDrivePreferencesStore';
 export { usePendingVerifyEmailStore } from './usePendingVerifyEmailStore';
+export { usePdfPreviewProgressStore, type PdfPreviewProgress } from './usePdfPreviewProgressStore';
 export { useRecentFilesStore, type RecentFileItem } from './useRecentFilesStore';

--- a/src/store/zustand/usePdfPreviewProgressStore.ts
+++ b/src/store/zustand/usePdfPreviewProgressStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface PdfPreviewProgress {
+  page: number;
+  zoom: string;
+}
+
+type PdfPreviewProgressState = {
+  progressByResourceId: Record<string, PdfPreviewProgress>;
+  setProgress: (resourceId: string, progress: PdfPreviewProgress) => void;
+  removeProgress: (resourceId: string) => void;
+};
+
+export const usePdfPreviewProgressStore = create<PdfPreviewProgressState>()(
+  persist(
+    (set) => ({
+      progressByResourceId: {},
+
+      setProgress: (resourceId, progress) =>
+        set((state) => {
+          const prev = state.progressByResourceId[resourceId];
+          if (prev != null && prev.page === progress.page && prev.zoom === progress.zoom) {
+            return state;
+          }
+          return {
+            progressByResourceId: {
+              ...state.progressByResourceId,
+              [resourceId]: progress,
+            },
+          };
+        }),
+
+      removeProgress: (resourceId) =>
+        set((state) => {
+          if (state.progressByResourceId[resourceId] == null) {
+            return state;
+          }
+          const next = { ...state.progressByResourceId };
+          delete next[resourceId];
+          return { progressByResourceId: next };
+        }),
+    }),
+    { name: 'pdf-preview-progress' }
+  )
+);

--- a/src/store/zustand/useRecentFilesStore.ts
+++ b/src/store/zustand/useRecentFilesStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { usePdfPreviewProgressStore } from './usePdfPreviewProgressStore';
 
 export interface RecentFileItem {
   resourceId: string;
@@ -29,9 +30,12 @@ export const useRecentFilesStore = create<RecentFilesState>()(
         }),
 
       removeFile: (resourceId) =>
-        set((state) => ({
-          items: state.items.filter((i) => i.resourceId !== resourceId),
-        })),
+        set((state) => {
+          usePdfPreviewProgressStore.getState().removeProgress(resourceId);
+          return {
+            items: state.items.filter((i) => i.resourceId !== resourceId),
+          };
+        }),
 
       updateFileName: (resourceId, resourceName) =>
         set((state) => ({

--- a/src/views/drive/Drive/UploadDocumentModal.tsx
+++ b/src/views/drive/Drive/UploadDocumentModal.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Modal, Upload, Progress, message, Button } from 'antd';
+import { Modal, Upload, Progress, Button } from 'antd';
 import type { UploadFile, UploadProps } from 'antd';
 import { AiOutlineInbox } from 'react-icons/ai';
 
 import { useDocumentService } from '@/contexts/ServicesContext';
+import { useAppMessage } from '@/hooks/useAppMessage';
 import { parseErrorMessage } from '@/utils/parseErrorMessage';
 
 import styles from './UploadDocumentModal.module.less';
@@ -20,6 +21,7 @@ export interface UploadDocumentModalProps {
 export const UploadDocumentModal: React.FC<UploadDocumentModalProps> = ({ open, onClose }) => {
   const documentService = useDocumentService();
   const navigate = useNavigate();
+  const message = useAppMessage();
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [uploading, setUploading] = useState(false);
   const [phase, setPhase] = useState<'idle' | 'hash' | 'upload'>('idle');
@@ -100,7 +102,7 @@ export const UploadDocumentModal: React.FC<UploadDocumentModalProps> = ({ open, 
       okText="开始上传"
       okButtonProps={{ loading: uploading, disabled: fileList.length === 0 }}
       cancelButtonProps={{ disabled: uploading }}
-      destroyOnClose
+      destroyOnHidden
       width={520}
     >
       <p className={styles.hint}>支持 pdf、Office 文档等，单文件最大 100MB。</p>

--- a/src/views/pdf/index.tsx
+++ b/src/views/pdf/index.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
 
 import { useDocumentService } from '@/contexts/ServicesContext';
+import { type PdfPreviewProgress, usePdfPreviewProgressStore } from '@/store';
 
 import styles from './style.module.less';
 
@@ -11,7 +12,22 @@ import styles from './style.module.less';
  */
 const Pdf: React.FC = () => {
   const documentService = useDocumentService();
+  const location = useLocation();
   const { resourceId } = useParams();
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const setProgress = usePdfPreviewProgressStore((s) => s.setProgress);
+
+  const routeProgress = useMemo<PdfPreviewProgress | null>(() => {
+    const qs = new URLSearchParams(location.search);
+    const pageRaw = qs.get('page');
+    const zoomRaw = qs.get('zoom');
+    const page = pageRaw == null ? Number.NaN : Number(pageRaw);
+    const zoom = zoomRaw?.trim();
+    if (!Number.isInteger(page) || page <= 0 || !zoom) {
+      return null;
+    }
+    return { page, zoom };
+  }, [location.search]);
 
   const iframeSrc = useMemo(() => {
     const id = resourceId?.trim();
@@ -19,14 +35,67 @@ const Pdf: React.FC = () => {
       return '';
     }
     const pdfHref = documentService.getDocumentPreviewUrl(id);
+    const fallbackProgress = usePdfPreviewProgressStore.getState().progressByResourceId[id];
+    const initialProgress = routeProgress ?? fallbackProgress;
+
     const qs = new URLSearchParams({ file: pdfHref });
-    return `/pdfjs-5/web/viewer.html?${qs.toString()}`;
-  }, [documentService, resourceId]);
+    const hashQs = new URLSearchParams();
+    if (initialProgress != null) {
+      hashQs.set('page', String(initialProgress.page));
+      hashQs.set('zoom', initialProgress.zoom);
+    }
+    return hashQs.size > 0
+      ? `/pdfjs-5/web/viewer.html?${qs.toString()}#${hashQs.toString()}`
+      : `/pdfjs-5/web/viewer.html?${qs.toString()}`;
+  }, [documentService, resourceId, routeProgress]);
+
+  useEffect(() => {
+    const id = resourceId?.trim();
+    const iframe = iframeRef.current;
+    if (!id || iframe == null) {
+      return;
+    }
+
+    const saveProgress = (hash: string) => {
+      const hashQs = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+      const pageRaw = hashQs.get('page');
+      const zoomRaw = hashQs.get('zoom');
+      const page = pageRaw == null ? Number.NaN : Number(pageRaw);
+      const zoom = zoomRaw?.trim();
+      if (!Number.isInteger(page) || page <= 0 || !zoom) {
+        return;
+      }
+      setProgress(id, { page, zoom });
+    };
+
+    const bindViewerEvents = () => {
+      const win = iframe.contentWindow;
+      if (win == null) {
+        return;
+      }
+      saveProgress(win.location.hash);
+      const handleHashChange = () => saveProgress(win.location.hash);
+      win.addEventListener('hashchange', handleHashChange);
+      return () => win.removeEventListener('hashchange', handleHashChange);
+    };
+
+    let unbind = bindViewerEvents();
+    const handleLoad = () => {
+      unbind?.();
+      unbind = bindViewerEvents();
+    };
+    iframe.addEventListener('load', handleLoad);
+
+    return () => {
+      iframe.removeEventListener('load', handleLoad);
+      unbind?.();
+    };
+  }, [resourceId, setProgress]);
 
   return (
     <div className={styles.container}>
       {iframeSrc ? (
-        <iframe className={styles.viewer} title="PDF 阅读器" src={iframeSrc} />
+        <iframe ref={iframeRef} className={styles.viewer} title="PDF 阅读器" src={iframeSrc} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
- 在 PDF 预览中按 resourceId 持久化 page/zoom，打开文件时自动恢复上次阅读位置，关闭文件时清理对应进度
- 简化 Sidebar 菜单项类型与点击分发逻辑，统一文件打开行为
- 将上传弹窗消息切换为 App 上下文 message 以消除 antd 静态 API 警告