### PR TITLE
feat(wallet): 计算点钱包与高级组 Token 划拨

### DIFF
--- a/src/components/Group/OwnerGroupTokenTransfer/index.tsx
+++ b/src/components/Group/OwnerGroupTokenTransfer/index.tsx
@@ -1,0 +1,228 @@
+/**
+ * 高级组组长：个人计算点与小组池之间的 Token 划拨（giveTokenToGroup / giveTokenToOwner）。
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, InputNumber, Skeleton } from 'antd';
+import { useUserService, useWalletService } from '@/contexts/ServicesContext';
+import { WALLET_TARGET_TYPE } from '@/constants/wallet';
+import { parseErrorMessage } from '@/utils/parseErrorMessage';
+import { useAppMessage } from '@/hooks/useAppMessage';
+import type { OwnerGroupTokenTransferProps } from './index.type';
+import styles from './style.module.less';
+
+const OwnerGroupTokenTransfer: React.FC<OwnerGroupTokenTransferProps> = ({
+  groupId,
+  onTransferSuccess,
+}) => {
+  const userService = useUserService();
+  const walletService = useWalletService();
+  const message = useAppMessage();
+
+  const [userId, setUserId] = useState<string | null>(null);
+  const [userLoading, setUserLoading] = useState(true);
+  const [personalBal, setPersonalBal] = useState(0);
+  const [groupBal, setGroupBal] = useState(0);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+  const [amtToGroup, setAmtToGroup] = useState<number | null>(null);
+  const [amtToOwner, setAmtToOwner] = useState<number | null>(null);
+  const [submittingToGroup, setSubmittingToGroup] = useState(false);
+  const [submittingToOwner, setSubmittingToOwner] = useState(false);
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        setUserLoading(true);
+        const u = await userService.getUserInfo();
+        setUserId(u.id);
+      } catch {
+        setUserId(null);
+        message.error('获取当前用户失败');
+      } finally {
+        setUserLoading(false);
+      }
+    };
+    void run();
+  }, [userService, message]);
+
+  const loadBalances = useCallback(async () => {
+    if (!userId || !groupId) {
+      return;
+    }
+    setBalanceLoading(true);
+    try {
+      const [p, g] = await Promise.all([
+        walletService.getWalletInfo({
+          targetType: WALLET_TARGET_TYPE.USER,
+          targetId: userId,
+        }),
+        walletService.getWalletInfo({
+          targetType: WALLET_TARGET_TYPE.GROUP,
+          targetId: groupId,
+        }),
+      ]);
+      setPersonalBal(p.balance);
+      setGroupBal(g.balance);
+    } catch (err) {
+      message.error(parseErrorMessage(err, '获取余额失败'));
+    } finally {
+      setBalanceLoading(false);
+    }
+  }, [userId, groupId, walletService, message]);
+
+  useEffect(() => {
+    void loadBalances();
+  }, [loadBalances]);
+
+  /** 接口成功后统一：重拉本页两侧余额，并通知父级刷新「token明细」Tab 内钱包 */
+  const refreshAfterTransfer = useCallback(async () => {
+    await loadBalances();
+    onTransferSuccess?.();
+  }, [loadBalances, onTransferSuccess]);
+
+  const handleGiveToGroup = async () => {
+    const n = amtToGroup;
+    if (n == null || !Number.isFinite(n) || n <= 0) {
+      message.warning('请输入大于 0 的整数');
+      return;
+    }
+    if (n > personalBal) {
+      message.warning('组长个人计算点不足');
+      return;
+    }
+    setSubmittingToGroup(true);
+    try {
+      await walletService.giveTokenToGroup({ groupId, amount: Math.floor(n) });
+      message.success('已转入小组池');
+      setAmtToGroup(null);
+      await refreshAfterTransfer();
+    } catch (err) {
+      message.error(parseErrorMessage(err, '转入失败'));
+    } finally {
+      setSubmittingToGroup(false);
+    }
+  };
+
+  const handleGiveToOwner = async () => {
+    const n = amtToOwner;
+    if (n == null || !Number.isFinite(n) || n <= 0) {
+      message.warning('请输入大于 0 的整数');
+      return;
+    }
+    if (n > groupBal) {
+      message.warning('小组池计算点不足');
+      return;
+    }
+    setSubmittingToOwner(true);
+    try {
+      await walletService.giveTokenToOwner({ groupId, amount: Math.floor(n) });
+      message.success('已转回组长账户');
+      setAmtToOwner(null);
+      await refreshAfterTransfer();
+    } catch (err) {
+      message.error(parseErrorMessage(err, '转回失败'));
+    } finally {
+      setSubmittingToOwner(false);
+    }
+  };
+
+  if (userLoading) {
+    return (
+      <div className={styles.card}>
+        <Skeleton active paragraph={{ rows: 3 }} />
+      </div>
+    );
+  }
+
+  if (!userId) {
+    return <div className={styles.card}>无法获取登录用户信息，请重新登录后再试。</div>;
+  }
+
+  return (
+    <div className={styles.card}>
+      <p className={styles.intro}>
+        高级组的小组计算点仅组长可通过点卡充值；您也可以将组长个人账户中的计算点划入小组池，或将小组池余额转回个人账户，便于统一给组员分配使用。
+      </p>
+
+      <div className={styles.balanceHeader}>
+        <h3 className={styles.balanceTitle}>当前余额</h3>
+        <Button onClick={() => void loadBalances()} disabled={balanceLoading}>
+          刷新
+        </Button>
+      </div>
+      <div className={styles.balanceRow}>
+        <div className={styles.balanceItem}>
+          <p className={styles.balanceLabel}>组长个人计算点</p>
+          {balanceLoading ? (
+            <Skeleton.Input active className={styles.balanceSkeleton} size="small" />
+          ) : (
+            <p className={styles.balanceValue}>
+              {personalBal}
+              <span className={styles.unit}>点</span>
+            </p>
+          )}
+        </div>
+        <div className={styles.balanceItem}>
+          <p className={styles.balanceLabel}>小组池计算点</p>
+          {balanceLoading ? (
+            <Skeleton.Input active className={styles.balanceSkeleton} size="small" />
+          ) : (
+            <p className={styles.balanceValue}>
+              {groupBal}
+              <span className={styles.unit}>点</span>
+            </p>
+          )}
+        </div>
+      </div>
+
+      <hr className={styles.divider} />
+
+      <h4 className={styles.transferTitle}>划入小组池</h4>
+      <div className={styles.formRow}>
+        <InputNumber
+          className={styles.amountInput}
+          min={1}
+          max={personalBal > 0 ? personalBal : undefined}
+          precision={0}
+          placeholder="数量"
+          value={amtToGroup ?? undefined}
+          onChange={(v) => setAmtToGroup(typeof v === 'number' ? v : null)}
+          disabled={submittingToGroup || balanceLoading}
+        />
+        <Button
+          type="primary"
+          loading={submittingToGroup}
+          disabled={balanceLoading}
+          onClick={() => void handleGiveToGroup()}
+        >
+          确认转入小组
+        </Button>
+      </div>
+
+      <hr className={styles.divider} />
+
+      <h4 className={styles.transferTitle}>从小组池转回组长</h4>
+      <div className={styles.formRow}>
+        <InputNumber
+          className={styles.amountInput}
+          min={1}
+          max={groupBal > 0 ? groupBal : undefined}
+          precision={0}
+          placeholder="数量"
+          value={amtToOwner ?? undefined}
+          onChange={(v) => setAmtToOwner(typeof v === 'number' ? v : null)}
+          disabled={submittingToOwner || balanceLoading}
+        />
+        <Button
+          type="primary"
+          loading={submittingToOwner}
+          disabled={balanceLoading}
+          onClick={() => void handleGiveToOwner()}
+        >
+          确认转回组长
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OwnerGroupTokenTransfer;

--- a/src/components/Group/OwnerGroupTokenTransfer/index.type.ts
+++ b/src/components/Group/OwnerGroupTokenTransfer/index.type.ts
@@ -1,0 +1,5 @@
+export interface OwnerGroupTokenTransferProps {
+  groupId: string;
+  /** 划拨成功后回调（可选，用于联动刷新其它区块） */
+  onTransferSuccess?: () => void;
+}

--- a/src/components/Group/OwnerGroupTokenTransfer/style.module.less
+++ b/src/components/Group/OwnerGroupTokenTransfer/style.module.less
@@ -1,0 +1,94 @@
+// 与 Wallet/ComputeWallet 卡片风格对齐：同 token 变量与圆角边框
+
+.card {
+  padding: var(--ant-padding-lg);
+  margin-bottom: var(--ant-margin-lg);
+  background-color: var(--ant-color-bg-container);
+  border: 1px solid var(--ant-color-border-secondary);
+  border-radius: var(--ant-border-radius-lg);
+}
+
+.intro {
+  margin: 0 0 var(--ant-margin-md) 0;
+  color: var(--ant-color-text-secondary);
+  line-height: 1.6;
+  font-size: var(--ant-font-size);
+}
+
+/* 标题与刷新按钮紧邻排布，不撑满整行到最右侧 */
+.balanceHeader {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--ant-margin-sm);
+  margin-bottom: var(--ant-margin-md);
+}
+
+.balanceTitle {
+  margin: 0;
+  font-size: var(--ant-font-size-heading-5);
+  font-weight: 500;
+}
+
+.balanceRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ant-margin-lg);
+  margin-bottom: var(--ant-margin-lg);
+}
+
+.balanceItem {
+  flex: 1;
+  min-width: 160px;
+}
+
+.balanceLabel {
+  margin: 0 0 var(--ant-margin-xs) 0;
+  font-size: var(--ant-font-size);
+  color: var(--ant-color-text-secondary);
+}
+
+.balanceValue {
+  margin: 0;
+  font-size: var(--ant-font-size-heading-3);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--ant-color-text);
+}
+
+.unit {
+  margin-left: var(--ant-margin-xs);
+  font-size: var(--ant-font-size);
+  font-weight: 500;
+  color: var(--ant-color-text-secondary);
+}
+
+.divider {
+  margin: var(--ant-margin-lg) 0;
+  border: 0;
+  border-top: 1px solid var(--ant-color-border-secondary);
+}
+
+.transferTitle {
+  margin: 0 0 var(--ant-margin-sm) 0;
+  font-size: var(--ant-font-size);
+  font-weight: 500;
+  color: var(--ant-color-text);
+}
+
+.formRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--ant-margin-md);
+}
+
+.amountInput {
+  width: 200px;
+  max-width: 100%;
+}
+
+.balanceSkeleton {
+  width: 120px;
+  min-width: 120px;
+}

--- a/src/components/Wallet/ComputeWallet/index.tsx
+++ b/src/components/Wallet/ComputeWallet/index.tsx
@@ -1,0 +1,350 @@
+/**
+ * 通用计算点钱包模块：余额、点卡充值、交易明细分页与 Tab 筛选。
+ *
+ * 复用场景：
+ * - 个人中心 /app/profile/usage：targetType=USER，一般不展示操作人列。
+ * - 高级组详情「token明细」：targetType=GROUP，仅组长进入；展示操作人列。
+ *
+ * 体验约定：
+ * - 首次加载余额用骨架屏；充值后静默刷新余额并做数字缓动（Ticker）。
+ * - 充值成功后回到第一页拉流水，并对首行做一次高亮动画（模拟「新记录插入」反馈）。
+ */
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Button, Pagination, Skeleton, Table, Tabs } from 'antd';
+import { RiAddLine, RiArrowDownLine, RiArrowUpLine, RiSubtractLine } from 'react-icons/ri';
+import { useWalletService } from '@/contexts/ServicesContext';
+import { WALLET_TX_LIST_FILTER } from '@/constants/wallet';
+import type { WalletTransactionRecord } from '@/types/wallet';
+import { parseErrorMessage } from '@/utils/parseErrorMessage';
+import { useAppMessage } from '@/hooks/useAppMessage';
+import RechargeModal from '@/components/Wallet/RechargeModal';
+import type { ComputeWalletProps } from './index.type';
+import styles from './style.module.less';
+
+type TabKey = 'all' | 'recharge' | 'spend';
+
+/** 需求默认每页 20 条流水 */
+const PAGE_SIZE = 20;
+
+/** UI Tab → getTransactions 的 type：0 全部 / 1 充值 / 2 消费 */
+const tabToFilter = (key: TabKey): 0 | 1 | 2 => {
+  if (key === 'recharge') return WALLET_TX_LIST_FILTER.RECHARGE;
+  if (key === 'spend') return WALLET_TX_LIST_FILTER.SPEND;
+  return WALLET_TX_LIST_FILTER.ALL;
+};
+
+const ComputeWallet: React.FC<ComputeWalletProps> = ({
+  targetType,
+  targetId,
+  canRecharge,
+  groupDisplayName,
+  showOperatorColumn = false,
+  syncRevision,
+}) => {
+  const walletService = useWalletService();
+  const message = useAppMessage();
+  /** 界面展示用余额（可能与接口瞬时一致，充值时会做动画插值） */
+  const [displayBalance, setDisplayBalance] = useState(0);
+  const [loadingWallet, setLoadingWallet] = useState(true);
+  const [tab, setTab] = useState<TabKey>('all');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [records, setRecords] = useState<WalletTransactionRecord[]>([]);
+  const [loadingTx, setLoadingTx] = useState(true);
+  const [rechargeOpen, setRechargeOpen] = useState(false);
+  /** 充值成功后短时间内给表格第一行加高亮 class */
+  const [flashFirstRow, setFlashFirstRow] = useState(false);
+  /** 首次拉取余额时不做动画，避免从 0「假滚动」 */
+  const firstBalanceRef = useRef(true);
+  const rafRef = useRef<number | null>(null);
+  /** 供充值前记录旧余额、与动画起点同步（避免闭包读到陈旧 state） */
+  const displayBalanceRef = useRef(0);
+
+  useEffect(() => {
+    displayBalanceRef.current = displayBalance;
+  }, [displayBalance]);
+
+  /**
+   * 余额缓动：从 from 到 to，ease-out 二次曲线，时长约 650ms。
+   * 新动画开始前会 cancel 上一帧，防止快速连续充值时数字乱跳。
+   */
+  const runBalanceAnimation = useCallback((from: number, to: number) => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+    }
+    const duration = 650;
+    const start = performance.now();
+    const step = (now: number) => {
+      const t = Math.min(1, (now - start) / duration);
+      const eased = 1 - (1 - t) ** 2;
+      setDisplayBalance(Math.round(from + (to - from) * eased));
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      } else {
+        rafRef.current = null;
+      }
+    };
+    rafRef.current = requestAnimationFrame(step);
+  }, []);
+
+  /**
+   * 拉取最新余额。
+   * - silent：充值后不再顶骨架屏，仅更新数字（必要时带动画）。
+   * - animateFrom：从指定旧值动画到服务端返回的新值，满足「Ticker」体验。
+   */
+  const loadBalance = useCallback(
+    async (options?: { animateFrom?: number; silent?: boolean }) => {
+      if (!options?.silent) {
+        setLoadingWallet(true);
+      }
+      try {
+        const { balance: b } = await walletService.getWalletInfo({ targetType, targetId });
+        if (firstBalanceRef.current) {
+          setDisplayBalance(b);
+          firstBalanceRef.current = false;
+        } else if (options?.animateFrom !== undefined) {
+          runBalanceAnimation(options.animateFrom, b);
+        } else {
+          setDisplayBalance(b);
+        }
+      } catch (err) {
+        message.error(parseErrorMessage(err, '获取余额失败'));
+      } finally {
+        if (!options?.silent) {
+          setLoadingWallet(false);
+        }
+      }
+    },
+    [walletService, targetType, targetId, message, runBalanceAnimation]
+  );
+
+  const loadTransactions = useCallback(
+    async (p: number, tabKey: TabKey) => {
+      setLoadingTx(true);
+      try {
+        const typeFilter = tabToFilter(tabKey);
+        const { total: t, records: list } = await walletService.listTransactions({
+          targetType,
+          targetId,
+          page: p,
+          size: PAGE_SIZE,
+          type: typeFilter,
+        });
+        setTotal(t);
+        setRecords(list);
+      } catch (err) {
+        message.error(parseErrorMessage(err, '获取交易明细失败'));
+        setRecords([]);
+        setTotal(0);
+      } finally {
+        setLoadingTx(false);
+      }
+    },
+    [walletService, targetType, targetId, message]
+  );
+
+  useEffect(() => {
+    void loadBalance();
+  }, [loadBalance]);
+
+  useEffect(() => {
+    void loadTransactions(page, tab);
+  }, [loadTransactions, page, tab]);
+
+  /** 外部划拨等操作后由父级递增 syncRevision，避免整页 Tabs items 重建 */
+  useEffect(() => {
+    if (syncRevision == null || syncRevision < 1) {
+      return;
+    }
+    void loadBalance({ silent: true });
+    void loadTransactions(page, tab);
+  }, [syncRevision, loadBalance, loadTransactions, page, tab]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const handleRechargeSubmit = async (code: string) => {
+    const from = displayBalanceRef.current;
+    try {
+      await walletService.redeemVoucher({ targetType, targetId, code });
+      /** 接口 data 为 null，到账金额以刷新后的 getWalletInfo 为准 */
+      message.success('充值成功');
+      await loadBalance({ animateFrom: from, silent: true });
+      setPage(1);
+      await loadTransactions(1, tab);
+      setFlashFirstRow(true);
+      window.setTimeout(() => setFlashFirstRow(false), 2400);
+    } catch (err) {
+      message.error(parseErrorMessage(err, '充值失败'));
+      throw err;
+    }
+  };
+
+  const handleTabChange = (key: string) => {
+    setTab(key as TabKey);
+    setPage(1);
+  };
+
+  type Row = WalletTransactionRecord & { key: React.Key };
+
+  const columns = useMemo(() => {
+    const cols: {
+      title: string;
+      dataIndex?: string;
+      key: string;
+      width?: number;
+      align?: 'right';
+      render?: (v: unknown, row: Row) => React.ReactNode;
+    }[] = [
+      {
+        title: '时间',
+        dataIndex: 'time',
+        key: 'time',
+        width: 180,
+      },
+      {
+        title: '类型',
+        dataIndex: 'type',
+        key: 'type',
+        width: 120,
+        render: (t: unknown) => {
+          const kind = t as WalletTransactionRecord['type'];
+          return (
+            <span className={styles.typeCell}>
+              {kind === 'RECHARGE' ? (
+                <>
+                  <RiArrowUpLine size={16} className={styles.amountRecharge} />
+                  <RiAddLine size={14} className={styles.amountRecharge} />
+                  <span>充值</span>
+                </>
+              ) : (
+                <>
+                  <RiArrowDownLine size={16} className={styles.amountSpend} />
+                  <RiSubtractLine size={14} className={styles.amountSpend} />
+                  <span>消费</span>
+                </>
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        title: '摘要 / 备注',
+        key: 'summary',
+        render: (_: unknown, row: Row) => (
+          <div>
+            <div className={styles.summaryMain}>{row.title || '—'}</div>
+            <div className={styles.summarySub}>{row.subTitle || '—'}</div>
+          </div>
+        ),
+      },
+      {
+        title: '变动金额',
+        dataIndex: 'amount',
+        key: 'amount',
+        width: 120,
+        align: 'right',
+        render: (amount: unknown, row: Row) => {
+          const isRecharge = row.type === 'RECHARGE';
+          const n = Number(amount);
+          const prefix = n > 0 ? '+' : '';
+          return (
+            <span className={isRecharge ? styles.amountRecharge : styles.amountSpend}>
+              {prefix}
+              {n}
+            </span>
+          );
+        },
+      },
+    ];
+    if (showOperatorColumn) {
+      cols.push({
+        title: '操作人',
+        dataIndex: 'operatorName',
+        key: 'operatorName',
+        width: 120,
+        render: (name: unknown) => (name != null && String(name).length > 0 ? String(name) : '—'),
+      });
+    }
+    return cols;
+  }, [showOperatorColumn]);
+
+  const dataSource = useMemo(
+    () => records.map((r) => ({ ...r, key: r.traceId || r.time })),
+    [records]
+  );
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.assetRow}>
+        <div className={styles.balanceBlock}>
+          <p className={styles.balanceLabel}>计算点余额</p>
+          {loadingWallet ? (
+            <Skeleton.Input active style={{ width: 200, height: 44 }} />
+          ) : (
+            <p className={styles.balanceValue}>
+              {displayBalance}
+              <span className={styles.unit}>计算点</span>
+            </p>
+          )}
+        </div>
+        {canRecharge ? (
+          <Button type="primary" size="large" onClick={() => setRechargeOpen(true)}>
+            充值
+          </Button>
+        ) : null}
+      </div>
+
+      <h3 className={styles.panelTitle}>交易明细</h3>
+      <Tabs
+        className={styles.tabs}
+        activeKey={tab}
+        onChange={handleTabChange}
+        items={[
+          { key: 'all', label: '全部' },
+          { key: 'recharge', label: '充值' },
+          { key: 'spend', label: '消费' },
+        ]}
+      />
+
+      <Table
+        size="small"
+        columns={columns}
+        dataSource={dataSource}
+        loading={loadingTx}
+        pagination={false}
+        locale={{
+          emptyText: <div className={styles.empty}>暂无交易明细</div>,
+        }}
+        rowClassName={(_, index) => (flashFirstRow && index === 0 ? styles.rowFlash : '')}
+      />
+
+      {/* 仅多页时展示分页器，避免单页空白占位 */}
+      {total > 0 && Math.ceil(total / PAGE_SIZE) > 1 ? (
+        <Pagination
+          style={{ marginTop: 16, textAlign: 'right' }}
+          current={page}
+          pageSize={PAGE_SIZE}
+          total={total}
+          showSizeChanger={false}
+          onChange={(p) => setPage(p)}
+          showTotal={(t) => `共 ${t} 条`}
+        />
+      ) : null}
+
+      <RechargeModal
+        open={rechargeOpen}
+        onCancel={() => setRechargeOpen(false)}
+        groupDisplayName={groupDisplayName}
+        onSubmit={handleRechargeSubmit}
+      />
+    </div>
+  );
+};
+
+export default ComputeWallet;

--- a/src/components/Wallet/ComputeWallet/index.type.ts
+++ b/src/components/Wallet/ComputeWallet/index.type.ts
@@ -1,0 +1,31 @@
+import type { WalletTargetType } from '@/constants/wallet';
+
+/**
+ * 通用钱包组件 Props（个人中心 + 高级组 token明细 复用同一套 UI）。
+ */
+export interface ComputeWalletProps {
+  /** 资金主体：USER 个人 / GROUP 小组 */
+  targetType: WalletTargetType;
+  /**
+   * 主体 id：个人为用户 id（string，防大数精度丢失）；小组为 groupId。
+   * 与 getWalletInfo、redeemVoucher、getTransactions 的 targetId 一致。
+   */
+  targetId: string;
+  /**
+   * 是否展示「充值」入口。
+   * 个人场景恒为 true；小组场景仅组长应为 true（普通成员无权给组充值，也不应看到组流水）。
+   */
+  canRecharge: boolean;
+  /** 小组充值弹窗标题：为「为「xxx」充值」；个人不传则弹窗为「个人充值」 */
+  groupDisplayName?: string;
+  /**
+   * 是否在表格增加「操作人」列。
+   * 小组组长查看组账户流水时打开，用于展示充值人/消费人；个人钱包一般关闭。
+   */
+  showOperatorColumn?: boolean;
+  /**
+   * 父组件递增时静默刷新余额与当前页流水（如组长在「Token 划拨」操作后同步「token明细」）。
+   * 不传或始终为 0 时不触发该逻辑。
+   */
+  syncRevision?: number;
+}

--- a/src/components/Wallet/ComputeWallet/style.module.less
+++ b/src/components/Wallet/ComputeWallet/style.module.less
@@ -1,0 +1,103 @@
+// 通用钱包：资产区 + 流水表格 + 充值/消费配色（与需求「绿充红消」一致）
+
+.card {
+  padding: var(--ant-padding-lg);
+  margin-bottom: var(--ant-margin-lg);
+  background-color: var(--ant-color-bg-container);
+  border: 1px solid var(--ant-color-border-secondary);
+  border-radius: var(--ant-border-radius-lg);
+}
+
+.assetRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--ant-margin-md);
+}
+
+.balanceBlock {
+  flex: 1;
+  min-width: 200px;
+}
+
+.balanceLabel {
+  margin: 0 0 var(--ant-margin-xs) 0;
+  font-size: var(--ant-font-size);
+  color: var(--ant-color-text-secondary);
+}
+
+.balanceValue {
+  margin: 0;
+  font-size: 36px;
+  font-weight: 600;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  color: var(--ant-color-text);
+}
+
+.unit {
+  margin-left: var(--ant-margin-xs);
+  font-size: var(--ant-font-size-lg);
+  font-weight: 500;
+  color: var(--ant-color-text-secondary);
+}
+
+.panelTitle {
+  margin: 0 0 var(--ant-margin-md) 0;
+  font-size: var(--ant-font-size-heading-5);
+  font-weight: 500;
+}
+
+.tabs {
+  margin-bottom: var(--ant-margin-md);
+}
+
+.amountRecharge {
+  font-variant-numeric: tabular-nums;
+  color: var(--ant-color-success);
+  font-weight: 500;
+}
+
+.amountSpend {
+  font-variant-numeric: tabular-nums;
+  color: var(--ant-color-error);
+  font-weight: 500;
+}
+
+.typeCell {
+  display: flex;
+  align-items: center;
+  gap: var(--ant-margin-xs);
+}
+
+.summaryMain {
+  font-weight: 500;
+}
+
+.summarySub {
+  margin-top: 2px;
+  font-size: var(--ant-font-size-sm);
+  color: var(--ant-color-text-tertiary);
+}
+
+.empty {
+  padding: var(--ant-padding-xl);
+  text-align: center;
+  color: var(--ant-color-text-tertiary);
+}
+
+// 充值成功后首行短暂高亮（rowClassName 控制）
+.rowFlash {
+  animation: walletRowFlash 1.2s ease-out 2;
+}
+
+@keyframes walletRowFlash {
+  0%,
+  100% {
+    background-color: transparent;
+  }
+  25% {
+    background-color: var(--ant-color-success-bg);
+  }
+}

--- a/src/components/Wallet/RechargeModal/index.tsx
+++ b/src/components/Wallet/RechargeModal/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * 通用充值弹窗（点卡核销）。
+ *
+ * 交互要点（与需求文档一致）：
+ * - 展示格式：每满 4 位自动插入横杠，最多 16 位字母数字。
+ * - 强制大写：输入阶段即转大写，避免用户混淆。
+ * - 提交：剔除横杠与空格，仅传 16 位纯字符。
+ * - 防重复提交：进行中按钮文案为「充值中...」并禁用。
+ */
+import React, { useEffect, useState } from 'react';
+import { Input, Modal } from 'antd';
+import type { RechargeModalProps } from './index.type';
+import styles from './style.module.less';
+
+/** 将用户输入规范为「XXXX-XXXX-XXXX-XXXX」展示串（不含第 17 位及以后） */
+const formatVoucherDisplay = (raw: string): string => {
+  const alnum = raw
+    .replace(/[^0-9A-Za-z]/g, '')
+    .slice(0, 16)
+    .toUpperCase();
+  const parts = alnum.match(/.{1,4}/g) ?? [];
+  return parts.join('-');
+};
+
+/** 与后端 redeemVoucher 对齐：仅 16 位大写字母数字，无分隔符 */
+const toSubmitCode = (display: string): string => display.replace(/[^A-Z0-9]/gi, '').toUpperCase();
+
+const RechargeModal: React.FC<RechargeModalProps> = ({
+  open,
+  onCancel,
+  groupDisplayName,
+  onSubmit,
+}) => {
+  const [value, setValue] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setValue('');
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const title =
+    groupDisplayName != null && groupDisplayName.length > 0
+      ? `为「${groupDisplayName}」充值`
+      : '个人充值';
+
+  const handleOk = async () => {
+    const code = toSubmitCode(value);
+    if (code.length !== 16) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await onSubmit(code);
+      setValue('');
+      onCancel();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={title}
+      open={open}
+      onCancel={onCancel}
+      onOk={() => void handleOk()}
+      okText={submitting ? '充值中...' : '确认充值'}
+      okButtonProps={{
+        disabled: toSubmitCode(value).length !== 16 || submitting,
+        loading: submitting,
+      }}
+      destroyOnClose
+    >
+      <Input
+        size="large"
+        value={value}
+        onChange={(e) => setValue(formatVoucherDisplay(e.target.value))}
+        placeholder="XXXX-XXXX-XXXX-XXXX"
+        maxLength={19}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <p className={styles.hint}>请输入 16 位兑换码，将自动转为大写并分段显示。</p>
+    </Modal>
+  );
+};
+
+export default RechargeModal;

--- a/src/components/Wallet/RechargeModal/index.type.ts
+++ b/src/components/Wallet/RechargeModal/index.type.ts
@@ -1,0 +1,13 @@
+/**
+ * 点卡兑换弹窗：输入 xxxx-xxxx-xxxx-xxxx，提交 16 位无分隔大写串给后端。
+ */
+export interface RechargeModalProps {
+  open: boolean;
+  onCancel: () => void;
+  /** 有值时标题为小组充值样式；无值为个人充值 */
+  groupDisplayName?: string;
+  /**
+   * 提交兑换码。成功时应由父组件刷新余额/流水；失败须 throw，以便弹窗保持打开并展示错误。
+   */
+  onSubmit: (code: string) => Promise<void>;
+}

--- a/src/components/Wallet/RechargeModal/style.module.less
+++ b/src/components/Wallet/RechargeModal/style.module.less
@@ -1,0 +1,7 @@
+// 兑换码输入框下方说明文案
+
+.hint {
+  margin-top: var(--ant-margin-sm);
+  font-size: var(--ant-font-size-sm);
+  color: var(--ant-color-text-tertiary);
+}

--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -1,0 +1,16 @@
+/**
+ * 钱包资金归属主体，对应 targetType。
+ * - USER：个人账户（个人中心「余额与使用量」）
+ * - GROUP：小组账户（高级组详情「token明细」，仅组长可操作充值与查看全量流水）
+ */
+export const WALLET_TARGET_TYPE = { USER: 1, GROUP: 2 } as const;
+export type WalletTargetType = (typeof WALLET_TARGET_TYPE)[keyof typeof WALLET_TARGET_TYPE];
+
+/**
+ * getTransactions 的 type 参数约定（与后端对齐）：
+ * - ALL(0)：全部流水
+ * - RECHARGE(1)：仅充值
+ * - SPEND(2)：仅消费
+ */
+export const WALLET_TX_LIST_FILTER = { ALL: 0, RECHARGE: 1, SPEND: 2 } as const;
+export type WalletTxListFilter = (typeof WALLET_TX_LIST_FILTER)[keyof typeof WALLET_TX_LIST_FILTER];

--- a/src/contexts/ServicesContext.tsx
+++ b/src/contexts/ServicesContext.tsx
@@ -38,6 +38,8 @@ import type { IResourceService } from '@/services/Resource';
 import type { ITagService } from '@/services/Tag';
 import type { IStickerService } from '@/services/Sticker';
 import type { IUserService } from '@/services/User';
+/** 计算点钱包：余额 / 点卡核销 / 交易明细分页 */
+import type { IWalletService } from '@/services/Wallet';
 
 // 第二步：导入真实实现（*Services.impl.ts，调用后端 API）
 import { AuthServicesImpl } from '@/services/Auth/AuthServices.impl';
@@ -51,6 +53,7 @@ import { ResourceServicesImpl } from '@/services/Resource/ResourceServices.impl'
 import { TagServicesImpl } from '@/services/Tag/TagServices.impl';
 import { StickerServicesImpl } from '@/services/Sticker/StickerServices.impl';
 import { UserServicesImpl } from '@/services/User/UserServices.impl';
+import { WalletServicesImpl } from '@/services/Wallet/WalletServices.impl';
 
 // 第三步：导入 Mock 实现（src/mocks/Xxx/XxxServices.mock.ts，用于 MODE === 'mock' 时）
 import { AuthServicesMock } from '@/mocks/Auth/AuthServices.mock';
@@ -64,6 +67,7 @@ import { ResourceServicesMock } from '@/mocks/Resource/ResourceServices.mock';
 import { TagServicesMock } from '@/mocks/Tag/TagServices.mock';
 import { StickerServicesMock } from '@/mocks/Sticker/StickerServices.mock';
 import { UserServicesMock } from '@/mocks/User/UserServices.mock';
+import { WalletServicesMock } from '@/mocks/Wallet/WalletServices.mock';
 
 // 第四步：在 ServicesContextValue 中新增该服务的类型
 // Context 通过此 interface 与 Service/Mock 层约定「有哪些服务可被注入」
@@ -79,6 +83,8 @@ export interface ServicesContextValue {
   sticker: IStickerService;
   tag: ITagService;
   user: IUserService;
+  /** 见 src/services/Wallet */
+  wallet: IWalletService;
 }
 
 // 第五步：在 servicesValue 中绑定真实实现
@@ -94,6 +100,7 @@ const servicesValue: ServicesContextValue = {
   sticker: StickerServicesImpl,
   tag: TagServicesImpl,
   user: UserServicesImpl,
+  wallet: WalletServicesImpl,
 };
 
 // 第六步：在 mockServicesValue 中绑定 Mock 实现
@@ -109,6 +116,7 @@ const mockServicesValue: ServicesContextValue = {
   sticker: StickerServicesMock,
   tag: TagServicesMock,
   user: UserServicesMock,
+  wallet: WalletServicesMock,
 };
 
 // 第七步：导出 useXxxService hook，组件内通过 useOrderService() 等获取实例
@@ -123,6 +131,8 @@ export const useResourceService = (): IResourceService => useServicesContext().r
 export const useStickerService = (): IStickerService => useServicesContext().sticker;
 export const useTagService = (): ITagService => useServicesContext().tag;
 export const useUserService = (): IUserService => useServicesContext().user;
+/** 个人中心钱包、高级组 token 相关页注入 */
+export const useWalletService = (): IWalletService => useServicesContext().wallet;
 
 // ==================== 以上为新增服务时的 7 步注册 ====================
 

--- a/src/mocks/Wallet/WalletServices.mock.ts
+++ b/src/mocks/Wallet/WalletServices.mock.ts
@@ -1,0 +1,84 @@
+/**
+ * 钱包 Mock：供 vite MODE === 'mock' 时本地演示充值与流水筛选。
+ *
+ * 联调约定（便于手工验错）：
+ * - 兑换码全 0：模拟「点卡已使用」
+ * - 兑换码全 F：模拟「无效兑换码」
+ * - 其它任意 16 位：成功（与真实接口一致不返回 data），本地仍更新余额与流水列表
+ */
+import type { IWalletService } from '@/services/Wallet';
+import type { WalletTransactionRecord } from '@/types/wallet';
+import mockdata from './mockdata.json';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let mockTokenBalance = Number(mockdata.tokenBalance) || 0;
+let mockTokenUsed = Number(mockdata.tokenUsed) || 0;
+const allRecords = [...(mockdata.transactions.records as WalletTransactionRecord[])];
+
+const getWalletInfo: IWalletService['getWalletInfo'] = async () => {
+  await delay(280);
+  return {
+    tokenBalance: mockTokenBalance,
+    tokenUsed: mockTokenUsed,
+    balance: mockTokenBalance,
+  };
+};
+
+const redeemVoucher: IWalletService['redeemVoucher'] = async (params) => {
+  await delay(400);
+  const code = params.code.replace(/[\s-]/g, '').toUpperCase();
+  if (code.length !== 16) {
+    throw new Error('请输入 16 位兑换码');
+  }
+  if (code === '0000000000000000') {
+    throw new Error('点卡已使用');
+  }
+  if (code === 'FFFFFFFFFFFFFFFF') {
+    throw new Error('无效兑换码');
+  }
+  const amount = 500;
+  mockTokenBalance += amount;
+  const traceId = `mock-${Date.now()}`;
+  allRecords.unshift({
+    traceId,
+    time: new Date().toISOString().slice(0, 19).replace('T', ' '),
+    type: 'RECHARGE',
+    amount,
+    title: '点卡充值',
+    subTitle: `****${code.slice(-4)}`,
+    operatorName: '我',
+  });
+};
+
+const listTransactions: IWalletService['listTransactions'] = async (params) => {
+  await delay(260);
+  const { page = 1, size = 20, type: typeParam } = params;
+  const type = typeParam ?? 0;
+  let rows = [...allRecords];
+  // type 0：全部；1 / 2 见筛选分支
+  if (type === 1) {
+    rows = rows.filter((r) => r.type === 'RECHARGE');
+  } else if (type === 2) {
+    rows = rows.filter((r) => r.type === 'SPEND');
+  }
+  const start = (page - 1) * size;
+  const slice = rows.slice(start, start + size);
+  return { total: rows.length, records: slice };
+};
+
+const giveTokenToGroup: IWalletService['giveTokenToGroup'] = async () => {
+  await delay(200);
+};
+
+const giveTokenToOwner: IWalletService['giveTokenToOwner'] = async () => {
+  await delay(200);
+};
+
+export const WalletServicesMock: IWalletService = {
+  getWalletInfo,
+  redeemVoucher,
+  listTransactions,
+  giveTokenToGroup,
+  giveTokenToOwner,
+};

--- a/src/mocks/Wallet/mockdata.json
+++ b/src/mocks/Wallet/mockdata.json
@@ -1,0 +1,36 @@
+{
+  "tokenBalance": 3200,
+  "tokenUsed": 180,
+  "transactions": {
+    "total": 3,
+    "records": [
+      {
+        "traceId": "mock-1",
+        "time": "2025-12-20 14:30:00",
+        "type": "RECHARGE",
+        "amount": 1000,
+        "title": "点卡充值",
+        "subTitle": "****8829",
+        "operatorName": "张三"
+      },
+      {
+        "traceId": "mock-2",
+        "time": "2025-12-21 09:15:00",
+        "type": "SPEND",
+        "amount": -120,
+        "title": "AI 服务调用",
+        "subTitle": "GPT-4-Turbo",
+        "operatorName": "张三"
+      },
+      {
+        "traceId": "mock-3",
+        "time": "2025-12-22 11:00:00",
+        "type": "RECHARGE",
+        "amount": 500,
+        "title": "点卡充值",
+        "subTitle": "****1001",
+        "operatorName": "李四"
+      }
+    ]
+  }
+}

--- a/src/services/Wallet/WalletServices.impl.ts
+++ b/src/services/Wallet/WalletServices.impl.ts
@@ -1,0 +1,164 @@
+/**
+ * 钱包 Service 真实实现：对接 /group/member 下钱包相关接口。
+ *
+ * - 成功判定：`checkResponse`，即 `code === 200`。
+ * - 点卡充值：`redeemVoucher`（兑换码）；非 `giveToken*`，后两者为按数额在个人账户与小组池之间划拨。
+ * - getTransactions：data 为分页体 total/page/size/totalPage/list；项含 traceId、changeType、amount、meta、createTime 等。
+ *   query 始终带 `type`，`0` 全部、`1` 充值、`2` 消费（未传时默认 `0`）。
+ */
+import Axios from '@/utils/Axios';
+import { checkResponse } from '@/utils/response';
+import type { ApiResponse } from '@/types/api';
+import type { WalletTransactionKind, WalletTransactionRecord } from '@/types/wallet';
+import type {
+  GetWalletInfoRequest,
+  GetWalletInfoResponse,
+  RedeemVoucherRequest,
+  ListWalletTransactionsRequest,
+  ListWalletTransactionsResponse,
+  GiveTokenToGroupRequest,
+  GiveTokenToOwnerRequest,
+  IWalletService,
+} from './index.type';
+
+const toNum = (v: unknown, fallback = 0): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+/**
+ * 将接口原始 type 转为领域枚举（旧字段兼容）。
+ * 兼容：'RECHARGE'/'SPEND'、数字 1/2、以及包含关键字的字符串。
+ */
+const mapTxKind = (raw: unknown): WalletTransactionKind => {
+  if (raw === 'RECHARGE' || raw === 1 || raw === '1') return 'RECHARGE';
+  if (raw === 'SPEND' || raw === 2 || raw === '2') return 'SPEND';
+  const s = String(raw ?? '').toUpperCase();
+  if (s.includes('RECHARGE') || s.includes('CHARGE')) return 'RECHARGE';
+  return 'SPEND';
+};
+
+/**
+ * changeType 与列表筛选 type 一致：1=充值/入账，2=消费/出账；
+ * 未识别时按 amount 正负推断，再默认 SPEND。
+ */
+const mapChangeTypeToKind = (changeType: unknown, amountNum: number): WalletTransactionKind => {
+  if (changeType === 1 || changeType === '1') return 'RECHARGE';
+  if (changeType === 2 || changeType === '2') return 'SPEND';
+  if (amountNum > 0) return 'RECHARGE';
+  if (amountNum < 0) return 'SPEND';
+  return 'SPEND';
+};
+
+const defaultTitleForKind = (k: WalletTransactionKind): string =>
+  k === 'RECHARGE' ? '充值' : '消费';
+
+/**
+ * getTransactions 单条 list 项 → 领域记录。
+ * 新字段：changeType、amount（可为字符串）、meta、createTime；仍兼容旧 title/type/time。
+ */
+const mapTransactionRow = (row: Record<string, unknown>): WalletTransactionRecord => {
+  const amountNum = toNum(row.amount, 0);
+  const hasChangeType = row.changeType !== undefined && row.changeType !== null;
+  const kind = hasChangeType ? mapChangeTypeToKind(row.changeType, amountNum) : mapTxKind(row.type);
+  const time = String(row.createTime ?? row.time ?? row.createdAt ?? '');
+  const titleFromApi =
+    row.title != null && String(row.title).trim().length > 0 ? String(row.title) : '';
+  const title = titleFromApi || defaultTitleForKind(kind);
+  const subFromMeta = row.meta != null && String(row.meta).length > 0 ? String(row.meta) : '';
+  const subFromLegacy =
+    row.subTitle != null && String(row.subTitle).length > 0
+      ? String(row.subTitle)
+      : String(row.subtitle ?? '');
+  const subTitle = subFromMeta || subFromLegacy;
+  return {
+    traceId: String(row.traceId ?? row.id ?? ''),
+    time,
+    type: kind,
+    amount: amountNum,
+    title,
+    subTitle,
+    operatorName:
+      row.operatorName != null && String(row.operatorName).trim().length > 0
+        ? String(row.operatorName)
+        : undefined,
+  };
+};
+
+const getWalletInfo = async (params: GetWalletInfoRequest): Promise<GetWalletInfoResponse> => {
+  const res = (await Axios.get('/group/member/getWalletInfo', {
+    params: {
+      targetType: params.targetType,
+      targetId: params.targetId,
+    },
+  })) as ApiResponse<Record<string, unknown>>;
+  checkResponse(res);
+  const data = res.data ?? {};
+  const tokenBalance = toNum(
+    data.tokenBalance ?? data.TokenBalance ?? data.balance ?? data.Balance,
+    0
+  );
+  const tokenUsed = toNum(data.tokenUsed ?? data.TokenUsed, 0);
+  return {
+    tokenBalance,
+    tokenUsed,
+    balance: tokenBalance,
+  };
+};
+
+const redeemVoucher = async (params: RedeemVoucherRequest): Promise<void> => {
+  const res = (await Axios.post('/group/member/redeemVoucher', {
+    targetType: params.targetType,
+    targetId: params.targetId,
+    code: params.code,
+  })) as ApiResponse<unknown>;
+  checkResponse(res);
+};
+
+const listTransactions = async (
+  params: ListWalletTransactionsRequest
+): Promise<ListWalletTransactionsResponse> => {
+  const query: Record<string, string | number> = {
+    targetType: params.targetType,
+    targetId: params.targetId,
+    page: params.page ?? 1,
+    size: params.size ?? 20,
+    /** 0 全部 / 1 充值 / 2 消费 */
+    type: params.type ?? 0,
+  };
+  const res = (await Axios.get('/group/member/getTransactions', {
+    params: query,
+  })) as ApiResponse<Record<string, unknown>>;
+  checkResponse(res);
+  const data = (res.data ?? {}) as Record<string, unknown>;
+  const rawList = data.list ?? data.records ?? [];
+  const list = Array.isArray(rawList) ? rawList : [];
+  const records = list
+    .filter((r): r is Record<string, unknown> => r != null && typeof r === 'object')
+    .map((r) => mapTransactionRow(r));
+  return { total: toNum(data.total, records.length), records };
+};
+
+const giveTokenToGroup = async (params: GiveTokenToGroupRequest): Promise<void> => {
+  const res = (await Axios.post('/group/member/giveTokenToGroup', {
+    groupId: params.groupId,
+    amount: params.amount,
+  })) as ApiResponse<unknown>;
+  checkResponse(res);
+};
+
+const giveTokenToOwner = async (params: GiveTokenToOwnerRequest): Promise<void> => {
+  const res = (await Axios.post('/group/member/giveTokenToOwner', {
+    groupId: params.groupId,
+    amount: params.amount,
+  })) as ApiResponse<unknown>;
+  checkResponse(res);
+};
+
+export const WalletServicesImpl: IWalletService = {
+  getWalletInfo,
+  redeemVoucher,
+  listTransactions,
+  giveTokenToGroup,
+  giveTokenToOwner,
+};

--- a/src/services/Wallet/index.ts
+++ b/src/services/Wallet/index.ts
@@ -1,0 +1,11 @@
+/** 对外仅导出类型；实现放在 WalletServices.impl / Mock，由 ServicesContext 注入 */
+export type {
+  IWalletService,
+  GetWalletInfoRequest,
+  GetWalletInfoResponse,
+  RedeemVoucherRequest,
+  ListWalletTransactionsRequest,
+  ListWalletTransactionsResponse,
+  GiveTokenToGroupRequest,
+  GiveTokenToOwnerRequest,
+} from './index.type';

--- a/src/services/Wallet/index.type.ts
+++ b/src/services/Wallet/index.type.ts
@@ -1,0 +1,80 @@
+import type { WalletTransactionRecord } from '@/types/wallet';
+
+/**
+ * IWalletService：计算点余额、点卡核销、交易明细分页。
+ * 实现类禁止被组件直接 import，统一通过 useWalletService() 注入。
+ */
+
+/** GET /group/member/getWalletInfo */
+export interface GetWalletInfoRequest {
+  /** 见 constants/wallet WALLET_TARGET_TYPE */
+  targetType: number;
+  /** 用户 id 或小组 id（大数场景下可用 string 传参，避免精度问题） */
+  targetId: string | number;
+}
+
+/**
+ * 与接口 data 对齐：tokenBalance / tokenUsed。
+ * balance 与 tokenBalance 同值，供展示「当前可用计算点」时直接使用。
+ */
+export interface GetWalletInfoResponse {
+  tokenBalance: number;
+  tokenUsed: number;
+  /** 等于 tokenBalance，便于组件统一用 balance 展示余量 */
+  balance: number;
+}
+
+/** POST /group/member/redeemVoucher —— 成功时 data 为 null，无业务载荷 */
+export interface RedeemVoucherRequest {
+  targetType: number;
+  targetId: string | number;
+  /** 已剔除横杠与空格后的 16 位纯字符（大写），由前端在提交前规范化 */
+  code: string;
+}
+
+/** GET /group/member/getTransactions */
+export interface ListWalletTransactionsRequest {
+  targetType: number;
+  targetId: string | number;
+  page?: number;
+  size?: number;
+  /**
+   * 流水类型：0 全部；1 充值；2 消费。
+   * 未传时由实现层默认 0。
+   */
+  type?: 0 | 1 | 2;
+}
+
+/**
+ * 领域层分页结果。接口 data 另有 page、size、totalPage；列表仅使用 list。
+ */
+export interface ListWalletTransactionsResponse {
+  total: number;
+  records: WalletTransactionRecord[];
+}
+
+/**
+ * POST /group/member/giveTokenToGroup
+ * 将当前用户个人 Token 划转到指定小组池（与点卡兑换码 redeemVoucher 不同）。
+ */
+export interface GiveTokenToGroupRequest {
+  groupId: string | number;
+  amount: number;
+}
+
+/**
+ * POST /group/member/giveTokenToOwner
+ * 将小组池 Token 划转回组长个人账户等业务语义由后端定义（与兑换码无关）。
+ */
+export interface GiveTokenToOwnerRequest {
+  groupId: string | number;
+  amount: number;
+}
+
+export interface IWalletService {
+  getWalletInfo(params: GetWalletInfoRequest): Promise<GetWalletInfoResponse>;
+  redeemVoucher(params: RedeemVoucherRequest): Promise<void>;
+  listTransactions(params: ListWalletTransactionsRequest): Promise<ListWalletTransactionsResponse>;
+  giveTokenToGroup(params: GiveTokenToGroupRequest): Promise<void>;
+  giveTokenToOwner(params: GiveTokenToOwnerRequest): Promise<void>;
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,23 @@
+/**
+ * 钱包流水领域类型（与需求文档「获取交易流水」Output 及前端表格展示对齐）。
+ */
+
+/** 流水业务类型：充值（点卡）或消费（算力使用等） */
+export type WalletTransactionKind = 'RECHARGE' | 'SPEND';
+
+/**
+ * 单条流水记录（Service 层由 getTransactions 的 list 项映射而来）。
+ * 接口字段：traceId、changeType、amount（可为字符串）、meta、operatorName、createTime。
+ * - title / subTitle：由 changeType 与 meta 等映射；展示用主副标题
+ * - amount：正数为入账，负数为出账
+ * - operatorName：小组流水等场景可选
+ */
+export interface WalletTransactionRecord {
+  traceId: string;
+  time: string;
+  type: WalletTransactionKind;
+  amount: number;
+  title: string;
+  subTitle: string;
+  operatorName?: string;
+}

--- a/src/views/group/GroupDetail/index.tsx
+++ b/src/views/group/GroupDetail/index.tsx
@@ -1,9 +1,14 @@
+/**
+ * 小组详情：高级组且组长可见「token明细」（点卡充值 + 流水）与「Token 划拨」（个人池 ↔ 小组池）。
+ */
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { Avatar, Button, Spin, Tabs } from 'antd';
 import { AiOutlineEdit, AiOutlineDelete, AiOutlineLogout } from 'react-icons/ai';
 import FlatDrive from '@/components/Drive/FlatDrive';
 import MemberList from '@/components/Group/MemberList';
+import ComputeWallet from '@/components/Wallet/ComputeWallet';
+import OwnerGroupTokenTransfer from '@/components/Group/OwnerGroupTokenTransfer';
 import { getPermissionConfig } from '@/components/Group/MemberList/PermissionConfig';
 import {
   EditGroupInfoModal,
@@ -12,7 +17,8 @@ import {
 } from '@/components/Group/GroupModals';
 import { useGroupService } from '@/contexts/ServicesContext';
 import type { Group } from '@/types/group';
-import { GROUP_TYPE, getGroupTypeLabel } from '@/constants/group';
+import { GROUP_TYPE } from '@/constants/group';
+import { WALLET_TARGET_TYPE } from '@/constants/wallet';
 import layout from '../style.module.less';
 import page from './style.module.less';
 import { useAppMessage } from '@/hooks/useAppMessage';
@@ -67,11 +73,105 @@ const GroupDetail: React.FC = () => {
   const [editGroupModalOpen, setEditGroupModalOpen] = useState(false);
   const [dissolveGroupModalOpen, setDissolveGroupModalOpen] = useState(false);
   const [exitGroupModalOpen, setExitGroupModalOpen] = useState(false);
+  /** 组长完成 Token 划拨后递增，传给 ComputeWallet.syncRevision 以静默刷新「token明细」Tab 内余额与流水 */
+  const [walletSyncRevision, setWalletSyncRevision] = useState(0);
+  /** Tabs 受控，避免 items 因 syncRevision 更新而重置当前选中的 Tab */
+  const [detailTabKey, setDetailTabKey] = useState<string>('files');
 
   const permissionConfig = useMemo(
     () => (group ? getPermissionConfig(group.groupType, currentUserRole) : null),
     [group, currentUserRole]
   );
+
+  /**
+   * Tabs 配置必须在任意 early return 之前计算，以符合 Hooks 规则。
+   * group/permissionConfig 为空时返回空数组（加载中或无效态不会渲染到 Tabs）。
+   */
+  const tabItems = useMemo(() => {
+    if (!group || !permissionConfig) {
+      return [];
+    }
+    const gid = group.groupId || id || '';
+    const { groupName: name, groupDesc: desc } = group;
+    const items = [
+      {
+        key: 'files',
+        label: '文件',
+        children: (
+          <div className={layout.tabPane}>
+            <FlatDrive groupId={gid} />
+          </div>
+        ),
+      },
+      {
+        key: 'members',
+        label: '成员列表',
+        children: (
+          <div className={layout.tabPane}>
+            <MemberList
+              permissionConfig={permissionConfig}
+              groupId={gid}
+              inviteCode={group.inviteCode}
+              pagination={{
+                defaultPageSize: 10,
+                pageSizeOptions: [5, 10, 20, 50],
+                showSizeChanger: true,
+              }}
+            />
+          </div>
+        ),
+      },
+    ];
+    if (group.groupType === GROUP_TYPE.ADVANCED && currentUserRole === 'OWNER') {
+      items.push({
+        key: 'wallet',
+        label: 'token 明细',
+        children: (
+          <div className={layout.tabPane}>
+            <ComputeWallet
+              targetType={WALLET_TARGET_TYPE.GROUP}
+              targetId={gid}
+              canRecharge
+              groupDisplayName={name}
+              showOperatorColumn
+              syncRevision={walletSyncRevision}
+            />
+          </div>
+        ),
+      });
+      items.push({
+        key: 'token-transfer',
+        label: 'token 划拨',
+        children: (
+          <div className={layout.tabPane}>
+            <OwnerGroupTokenTransfer
+              groupId={gid}
+              onTransferSuccess={() => setWalletSyncRevision((k) => k + 1)}
+            />
+          </div>
+        ),
+      });
+    }
+    items.push({
+      key: 'description',
+      label: '描述',
+      children: (
+        <div className={layout.tabPane}>
+          <p className={layout.sectionContent}>{desc || '暂无描述'}</p>
+        </div>
+      ),
+    });
+    return items;
+  }, [group, id, permissionConfig, currentUserRole, walletSyncRevision]);
+
+  const detailTabKeys = useMemo(() => tabItems.map((item) => String(item.key)), [tabItems]);
+
+  useEffect(() => {
+    if (detailTabKeys.length === 0) return;
+    if (!detailTabKeys.includes(detailTabKey)) {
+      setDetailTabKey(detailTabKeys[0] ?? 'files');
+    }
+  }, [detailTabKeys, detailTabKey]);
 
   if (loading) {
     return (
@@ -116,44 +216,9 @@ const GroupDetail: React.FC = () => {
 
       <Tabs
         className={layout.detailTabs}
-        items={[
-          {
-            key: 'files',
-            label: '文件',
-            children: (
-              <div className={layout.tabPane}>
-                <FlatDrive groupId={groupId} />
-              </div>
-            ),
-          },
-          {
-            key: 'members',
-            label: '成员列表',
-            children: (
-              <div className={layout.tabPane}>
-                <MemberList
-                  permissionConfig={permissionConfig!}
-                  groupId={groupId}
-                  inviteCode={group.inviteCode}
-                  pagination={{
-                    defaultPageSize: 10,
-                    pageSizeOptions: [5, 10, 20, 50],
-                    showSizeChanger: true,
-                  }}
-                />
-              </div>
-            ),
-          },
-          {
-            key: 'description',
-            label: '描述',
-            children: (
-              <div className={layout.tabPane}>
-                <p className={layout.sectionContent}>{description || '暂无描述'}</p>
-              </div>
-            ),
-          },
-        ]}
+        activeKey={detailTabKey}
+        onChange={setDetailTabKey}
+        items={tabItems}
       />
 
       <div className={layout.actionsBar}>

--- a/src/views/profile/Usage/index.tsx
+++ b/src/views/profile/Usage/index.tsx
@@ -1,11 +1,22 @@
+/**
+ * 个人中心「余额与使用量」：上半部分为个人计算点钱包（余额 + 点卡充值 + 流水），
+ * 下半部分仍为各小组配额（QuotaByGroup），二者数据来源不同、互不替代。
+ */
 import React, { useState, useEffect, useCallback } from 'react';
+import { Skeleton } from 'antd';
 import QuotaByGroup from '@/components/Profile/QuotaByGroup';
+import ComputeWallet from '@/components/Wallet/ComputeWallet';
+import { WALLET_TARGET_TYPE } from '@/constants/wallet';
 import type { UserGroupQuota } from '@/types/quota';
-import { useQuotaService } from '@/contexts/ServicesContext';
+import { useQuotaService, useUserService } from '@/contexts/ServicesContext';
 import layout from '../style.module.less';
 
 const Usage: React.FC = () => {
+  const userService = useUserService();
   const quotaService = useQuotaService();
+  /** 当前登录用户 id，供个人钱包 targetId；与 User 模型一致使用 string */
+  const [userId, setUserId] = useState<string | null>(null);
+  const [userLoading, setUserLoading] = useState(true);
   const [quotas, setQuotas] = useState<UserGroupQuota[]>([]);
   const [loading, setLoading] = useState(false);
   const [total, setTotal] = useState(0);
@@ -37,6 +48,21 @@ const Usage: React.FC = () => {
     fetchQuotas(page, pageSize);
   }, [fetchQuotas, page, pageSize]);
 
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        setUserLoading(true);
+        const u = await userService.getUserInfo();
+        setUserId(u.id);
+      } catch {
+        setUserId(null);
+      } finally {
+        setUserLoading(false);
+      }
+    };
+    void loadUser();
+  }, [userService]);
+
   const handlePageChange = (newPage: number, newPageSize: number) => {
     setPage(newPage);
     setPageSize(newPageSize);
@@ -46,8 +72,18 @@ const Usage: React.FC = () => {
     <div className={layout.pageContainer}>
       <div className={layout.pageHeader}>
         <h1 className={layout.pageTitle}>余额与使用量</h1>
-        <span className={layout.pageSubtitle}>查看您在各小组中的配额使用情况</span>
+        <span className={layout.pageSubtitle}>
+          查看个人计算点余额、点卡充值记录，以及在各小组中的配额使用情况
+        </span>
       </div>
+      {/* 先解析出 userId 再挂载钱包，避免 targetId 为空触发无效请求；等待期间用骨架占位 */}
+      {userLoading ? (
+        <div className={`${layout.formSection} ${layout.walletSkeletonWrap}`}>
+          <Skeleton active paragraph={{ rows: 4 }} />
+        </div>
+      ) : userId ? (
+        <ComputeWallet targetType={WALLET_TARGET_TYPE.USER} targetId={userId} canRecharge />
+      ) : null}
       <QuotaByGroup
         quotas={quotas}
         total={total}

--- a/src/views/profile/style.module.less
+++ b/src/views/profile/style.module.less
@@ -45,3 +45,8 @@
     color: var(--ant-color-text-tertiary);
   }
 }
+
+/* 「余额与使用量」页：个人钱包区块在拉取 userId 前的骨架容器下边距 */
+.walletSkeletonWrap {
+  margin-bottom: var(--ant-margin-lg);
+}


### PR DESCRIPTION
- 新增 WalletService（余额/流水/点卡核销、giveToken 双向）及 Mock

- 个人中心嵌入钱包；高级组组长可见 token明细 与 Token 划拨 Tab

- ComputeWallet、RechargeModal；划拨后 syncRevision 同步刷新流水