### PR TITLE
refactor(wallet): 将合并流水逻辑下沉到 WalletService

### DIFF
--- a/src/components/Wallet/ComputeWallet/index.tsx
+++ b/src/components/Wallet/ComputeWallet/index.tsx
@@ -1,28 +1,35 @@
 /**
  * 通用计算点钱包：个人余额走 /user/wallet；小组余额走 groupService.getGroupWalletInfo。
  * 点卡充值仅个人（redeemVoucher）；小组余额由组长通过「token 划拨」转入。
- * 交易明细支持 Tab：全部 / 充值 / 消费（对应 listTransactions 的 type 筛选）。
+ * 交易明细 Tab：全部 / 充值 / 消费。
+ * 个人「充值」仅 REFILL；小组「充值」合并 REFILL+TRANSFER_IN；「消费」合并 SPEND+TRANSFER_OUT；其余走单 type。
  * 数据请求使用 ahooks（不使用 useEffect）。
  */
 import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { usePagination, useRequest, useUnmount } from 'ahooks';
 import { Button, Pagination, Skeleton, Table, Tabs } from 'antd';
 import { RiAddLine, RiArrowDownLine, RiArrowUpLine, RiSubtractLine } from 'react-icons/ri';
-import { useWalletService } from '@/contexts/ServicesContext';
-import { useGroupService } from '@/contexts/ServicesContext';
-import { WALLET_TARGET_TYPE, WALLET_TOKEN_TX_TYPE } from '@/constants/wallet';
-import type { WalletTransactionKind, WalletTransactionRecord } from '@/types/wallet';
-import { parseErrorMessage } from '@/utils/parseErrorMessage';
-import { formatCompactNumber } from '@/utils/number';
-import { formatTimestampToDateTime } from '@/utils/time';
-import { useAppMessage } from '@/hooks/useAppMessage';
 import RechargeModal from '@/components/Wallet/RechargeModal';
+import {
+  WALLET_TARGET_TYPE,
+  WALLET_TOKEN_TX_TYPE,
+  WALLET_TX_TAB_MERGE_FETCH_CAP,
+} from '@/constants/wallet';
+import { useGroupService, useWalletService } from '@/contexts/ServicesContext';
+import { useAppMessage } from '@/hooks/useAppMessage';
+import type { IWalletService } from '@/services/Wallet';
+import type { WalletTransactionKind, WalletTransactionRecord } from '@/types/wallet';
+import { formatCompactNumber } from '@/utils/number';
+import { parseErrorMessage } from '@/utils/parseErrorMessage';
+import { formatTimestampToDateTime } from '@/utils/time';
 import type { ComputeWalletProps, ComputeWalletRef } from './index.type';
 import styles from './style.module.less';
 
 const PAGE_SIZE = 20;
 
 type TxTabKey = 'all' | 'recharge' | 'spend';
+
+type WalletTxTypeQueryCode = (typeof WALLET_TOKEN_TX_TYPE)[keyof typeof WALLET_TOKEN_TX_TYPE];
 
 const tabToListType = (key: TxTabKey): number | undefined => {
   if (key === 'recharge') return WALLET_TOKEN_TX_TYPE.REFILL;
@@ -31,6 +38,38 @@ const tabToListType = (key: TxTabKey): number | undefined => {
 };
 
 const isInflowKind = (k: WalletTransactionKind): boolean => k === 'RECHARGE' || k === 'TRANSFER_IN';
+
+/** 掩码行展示：全角 *、- 与半角混排时视觉大小不一，先规范再交给 summarySub 等宽样式 */
+const normalizeMaskDisplayText = (s: string): string =>
+  s.replace(/\uFF0A/g, '*').replace(/\uFF0D/g, '-');
+
+const txRecordDedupeKey = (r: WalletTransactionRecord): string =>
+  r.traceId.length > 0 ? r.traceId : `${r.time}\u0000${r.type}\u0000${r.amount}`;
+
+const compareWalletTxTimeDesc = (a: WalletTransactionRecord, b: WalletTransactionRecord): number =>
+  String(b.time).localeCompare(String(a.time));
+
+/** Tab 内合并两类流水：并行 listTransactions，合并去重、时间倒序再本地分页 */
+const mergeTwoTxTypesForTab = async (
+  wallet: IWalletService,
+  args: { groupId?: string; page: number; size: number },
+  typeA: WalletTxTypeQueryCode,
+  typeB: WalletTxTypeQueryCode
+): Promise<{ list: WalletTransactionRecord[]; total: number }> => {
+  const { groupId, page, size } = args;
+  const cap = WALLET_TX_TAB_MERGE_FETCH_CAP;
+  const [ra, rb] = await Promise.all([
+    wallet.listTransactions({ groupId, page: 1, size: cap, type: typeA }),
+    wallet.listTransactions({ groupId, page: 1, size: cap, type: typeB }),
+  ]);
+  const map = new Map<string, WalletTransactionRecord>();
+  for (const r of ra.records) map.set(txRecordDedupeKey(r), r);
+  for (const r of rb.records) map.set(txRecordDedupeKey(r), r);
+  const merged = [...map.values()].sort(compareWalletTxTimeDesc);
+  const total = ra.total + rb.total;
+  const start = (page - 1) * size;
+  return { list: merged.slice(start, start + size), total };
+};
 
 const typeLabel = (k: WalletTransactionKind): string => {
   switch (k) {
@@ -69,6 +108,7 @@ const ComputeWallet = React.forwardRef<ComputeWalletRef, ComputeWalletProps>(
     const [displayBalance, setDisplayBalance] = useState(0);
     const [loadingWallet, setLoadingWallet] = useState(true);
     const [txTab, setTxTab] = useState<TxTabKey>('all');
+    const txTabRef = useRef<TxTabKey>('all');
     const [rechargeOpen, setRechargeOpen] = useState(false);
     const [flashFirstRow, setFlashFirstRow] = useState(false);
     const firstBalanceRef = useRef(true);
@@ -151,12 +191,33 @@ const ComputeWallet = React.forwardRef<ComputeWalletRef, ComputeWalletProps>(
       pagination: { current: page = 1, total = 0, onChange: onTxPageChange },
     } = usePagination(
       async ({ current, pageSize }) => {
-        const listType = tabToListType(txTab);
+        const tab = txTabRef.current;
+        const gid =
+          targetType === WALLET_TARGET_TYPE.GROUP && effectiveGroupId
+            ? effectiveGroupId
+            : undefined;
+
+        if (tab === 'spend') {
+          return mergeTwoTxTypesForTab(
+            walletService,
+            { groupId: gid, page: current, size: pageSize },
+            WALLET_TOKEN_TX_TYPE.SPEND,
+            WALLET_TOKEN_TX_TYPE.TRANSFER_OUT
+          );
+        }
+
+        if (tab === 'recharge' && targetType === WALLET_TARGET_TYPE.GROUP && effectiveGroupId) {
+          return mergeTwoTxTypesForTab(
+            walletService,
+            { groupId: effectiveGroupId, page: current, size: pageSize },
+            WALLET_TOKEN_TX_TYPE.REFILL,
+            WALLET_TOKEN_TX_TYPE.TRANSFER_IN
+          );
+        }
+
+        const listType = tabToListType(tab);
         const { total: nextTotal, records } = await walletService.listTransactions({
-          groupId:
-            targetType === WALLET_TARGET_TYPE.GROUP && effectiveGroupId
-              ? effectiveGroupId
-              : undefined,
+          groupId: gid,
           page: current,
           size: pageSize,
           ...(listType !== undefined ? { type: listType } : {}),
@@ -222,7 +283,9 @@ const ComputeWallet = React.forwardRef<ComputeWalletRef, ComputeWalletProps>(
     };
 
     const handleTxTabChange = (key: string) => {
-      setTxTab(key as TxTabKey);
+      const next = key as TxTabKey;
+      txTabRef.current = next;
+      setTxTab(next);
       onTxPageChange(1, PAGE_SIZE);
     };
 
@@ -278,7 +341,9 @@ const ComputeWallet = React.forwardRef<ComputeWalletRef, ComputeWalletProps>(
           render: (_: unknown, row: Row) => (
             <div>
               <div className={styles.summaryMain}>{row.title || '—'}</div>
-              <div className={styles.summarySub}>{row.subTitle || '—'}</div>
+              <div className={styles.summarySub}>
+                {row.subTitle ? normalizeMaskDisplayText(row.subTitle) : '—'}
+              </div>
             </div>
           ),
         },

--- a/src/components/Wallet/ComputeWallet/index.tsx
+++ b/src/components/Wallet/ComputeWallet/index.tsx
@@ -2,7 +2,7 @@
  * 通用计算点钱包：个人余额走 /user/wallet；小组余额走 groupService.getGroupWalletInfo。
  * 点卡充值仅个人（redeemVoucher）；小组余额由组长通过「token 划拨」转入。
  * 交易明细 Tab：全部 / 充值 / 消费。
- * 个人「充值」仅 REFILL；小组「充值」合并 REFILL+TRANSFER_IN；「消费」合并 SPEND+TRANSFER_OUT；其余走单 type。
+ * 个人「充值」仅 REFILL；小组「充值」与「消费」通过 walletService.listMergedTransactions 合并两类流水；其余走 listTransactions。
  * 数据请求使用 ahooks（不使用 useEffect）。
  */
 import React, { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react';
@@ -10,14 +10,9 @@ import { usePagination, useRequest, useUnmount } from 'ahooks';
 import { Button, Pagination, Skeleton, Table, Tabs } from 'antd';
 import { RiAddLine, RiArrowDownLine, RiArrowUpLine, RiSubtractLine } from 'react-icons/ri';
 import RechargeModal from '@/components/Wallet/RechargeModal';
-import {
-  WALLET_TARGET_TYPE,
-  WALLET_TOKEN_TX_TYPE,
-  WALLET_TX_TAB_MERGE_FETCH_CAP,
-} from '@/constants/wallet';
+import { WALLET_TARGET_TYPE, WALLET_TOKEN_TX_TYPE } from '@/constants/wallet';
 import { useGroupService, useWalletService } from '@/contexts/ServicesContext';
 import { useAppMessage } from '@/hooks/useAppMessage';
-import type { IWalletService } from '@/services/Wallet';
 import type { WalletTransactionKind, WalletTransactionRecord } from '@/types/wallet';
 import { formatCompactNumber } from '@/utils/number';
 import { parseErrorMessage } from '@/utils/parseErrorMessage';
@@ -28,8 +23,6 @@ import styles from './style.module.less';
 const PAGE_SIZE = 20;
 
 type TxTabKey = 'all' | 'recharge' | 'spend';
-
-type WalletTxTypeQueryCode = (typeof WALLET_TOKEN_TX_TYPE)[keyof typeof WALLET_TOKEN_TX_TYPE];
 
 const tabToListType = (key: TxTabKey): number | undefined => {
   if (key === 'recharge') return WALLET_TOKEN_TX_TYPE.REFILL;
@@ -42,34 +35,6 @@ const isInflowKind = (k: WalletTransactionKind): boolean => k === 'RECHARGE' || 
 /** 掩码行展示：全角 *、- 与半角混排时视觉大小不一，先规范再交给 summarySub 等宽样式 */
 const normalizeMaskDisplayText = (s: string): string =>
   s.replace(/\uFF0A/g, '*').replace(/\uFF0D/g, '-');
-
-const txRecordDedupeKey = (r: WalletTransactionRecord): string =>
-  r.traceId.length > 0 ? r.traceId : `${r.time}\u0000${r.type}\u0000${r.amount}`;
-
-const compareWalletTxTimeDesc = (a: WalletTransactionRecord, b: WalletTransactionRecord): number =>
-  String(b.time).localeCompare(String(a.time));
-
-/** Tab 内合并两类流水：并行 listTransactions，合并去重、时间倒序再本地分页 */
-const mergeTwoTxTypesForTab = async (
-  wallet: IWalletService,
-  args: { groupId?: string; page: number; size: number },
-  typeA: WalletTxTypeQueryCode,
-  typeB: WalletTxTypeQueryCode
-): Promise<{ list: WalletTransactionRecord[]; total: number }> => {
-  const { groupId, page, size } = args;
-  const cap = WALLET_TX_TAB_MERGE_FETCH_CAP;
-  const [ra, rb] = await Promise.all([
-    wallet.listTransactions({ groupId, page: 1, size: cap, type: typeA }),
-    wallet.listTransactions({ groupId, page: 1, size: cap, type: typeB }),
-  ]);
-  const map = new Map<string, WalletTransactionRecord>();
-  for (const r of ra.records) map.set(txRecordDedupeKey(r), r);
-  for (const r of rb.records) map.set(txRecordDedupeKey(r), r);
-  const merged = [...map.values()].sort(compareWalletTxTimeDesc);
-  const total = ra.total + rb.total;
-  const start = (page - 1) * size;
-  return { list: merged.slice(start, start + size), total };
-};
 
 const typeLabel = (k: WalletTransactionKind): string => {
   switch (k) {
@@ -198,21 +163,27 @@ const ComputeWallet = React.forwardRef<ComputeWalletRef, ComputeWalletProps>(
             : undefined;
 
         if (tab === 'spend') {
-          return mergeTwoTxTypesForTab(
-            walletService,
-            { groupId: gid, page: current, size: pageSize },
-            WALLET_TOKEN_TX_TYPE.SPEND,
-            WALLET_TOKEN_TX_TYPE.TRANSFER_OUT
-          );
+          const { total: spendTotal, records: spendRecords } =
+            await walletService.listMergedTransactions({
+              groupId: gid,
+              page: current,
+              size: pageSize,
+              typeA: WALLET_TOKEN_TX_TYPE.SPEND,
+              typeB: WALLET_TOKEN_TX_TYPE.TRANSFER_OUT,
+            });
+          return { list: spendRecords, total: spendTotal };
         }
 
         if (tab === 'recharge' && targetType === WALLET_TARGET_TYPE.GROUP && effectiveGroupId) {
-          return mergeTwoTxTypesForTab(
-            walletService,
-            { groupId: effectiveGroupId, page: current, size: pageSize },
-            WALLET_TOKEN_TX_TYPE.REFILL,
-            WALLET_TOKEN_TX_TYPE.TRANSFER_IN
-          );
+          const { total: rechargeTotal, records: rechargeRecords } =
+            await walletService.listMergedTransactions({
+              groupId: effectiveGroupId,
+              page: current,
+              size: pageSize,
+              typeA: WALLET_TOKEN_TX_TYPE.REFILL,
+              typeB: WALLET_TOKEN_TX_TYPE.TRANSFER_IN,
+            });
+          return { list: rechargeRecords, total: rechargeTotal };
         }
 
         const listType = tabToListType(tab);

--- a/src/components/Wallet/ComputeWallet/style.module.less
+++ b/src/components/Wallet/ComputeWallet/style.module.less
@@ -88,6 +88,16 @@
   margin-top: 2px;
   font-size: var(--ant-font-size-sm);
   color: var(--ant-color-text-tertiary);
+  // 点卡尾号等掩码行：* 与数字在比例字体下宽窄不一，等宽栈 + tabular 数字对齐
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    'Segoe UI Mono',
+    Menlo,
+    Consolas,
+    'Liberation Mono',
+    monospace;
+  font-variant-numeric: tabular-nums;
 }
 
 .empty {

--- a/src/constants/wallet.ts
+++ b/src/constants/wallet.ts
@@ -6,7 +6,7 @@ export type WalletTargetType = (typeof WALLET_TARGET_TYPE)[keyof typeof WALLET_T
 
 /**
  * listTransactions 可选 type（与后端 TokenTransactionType 数值一致，Service 层会转为枚举名）。
- * 「全部」不传；Tab「充值」→ REFILL；「消费」→ SPEND。
+ * 「全部」不传；个人 Tab「充值」→ REFILL；小组「充值」前端合并 REFILL + TRANSFER_IN（划入）；「消费」合并 SPEND + TRANSFER_OUT。
  */
 export const WALLET_TOKEN_TX_TYPE = {
   REFILL: 1,
@@ -28,3 +28,6 @@ export const WALLET_LIST_TX_TYPE_QUERY_VALUE = {
 
 /** Owner↔Group 划拨：1 转入小组，2 转回组长 */
 export const WALLET_TOKEN_TRANSFER_TYPE = { TO_GROUP: 1, TO_OWNER: 2 } as const;
+
+/** Tab 内合并两类流水时，每类 listTransactions 的 size 上限（超出则分页可能不完整） */
+export const WALLET_TX_TAB_MERGE_FETCH_CAP = 500;

--- a/src/mocks/Wallet/WalletServices.mock.ts
+++ b/src/mocks/Wallet/WalletServices.mock.ts
@@ -1,6 +1,7 @@
 /**
  * 钱包 Mock：MODE === 'mock'；接口形态与 /user/wallet 对齐。
  */
+import { WALLET_TX_TAB_MERGE_FETCH_CAP } from '@/constants/wallet';
 import type { IWalletService } from '@/services/Wallet';
 import type { WalletTransactionRecord } from '@/types/wallet';
 import mockdata from './mockdata.json';
@@ -55,10 +56,37 @@ const listTransactions: IWalletService['listTransactions'] = async (params) => {
     rows = rows.filter((r) => r.type === 'RECHARGE');
   } else if (typeParam === 2) {
     rows = rows.filter((r) => r.type === 'SPEND');
+  } else if (typeParam === 3) {
+    rows = rows.filter((r) => r.type === 'TRANSFER_IN');
+  } else if (typeParam === 4) {
+    rows = rows.filter((r) => r.type === 'TRANSFER_OUT');
   }
   const start = (page - 1) * size;
   const slice = rows.slice(start, start + size);
   return { total: rows.length, records: slice };
+};
+
+const txRecordDedupeKey = (r: WalletTransactionRecord): string =>
+  r.traceId.length > 0 ? r.traceId : `${r.time}\u0000${r.type}\u0000${r.amount}`;
+
+const compareWalletTxTimeDesc = (a: WalletTransactionRecord, b: WalletTransactionRecord): number =>
+  String(b.time).localeCompare(String(a.time));
+
+const listMergedTransactions: IWalletService['listMergedTransactions'] = async (params) => {
+  await delay(260);
+  const { page = 1, size = 20, typeA, typeB } = params;
+  const cap = WALLET_TX_TAB_MERGE_FETCH_CAP;
+  const [ra, rb] = await Promise.all([
+    listTransactions({ ...params, page: 1, size: cap, type: typeA }),
+    listTransactions({ ...params, page: 1, size: cap, type: typeB }),
+  ]);
+  const map = new Map<string, WalletTransactionRecord>();
+  for (const r of ra.records) map.set(txRecordDedupeKey(r), r);
+  for (const r of rb.records) map.set(txRecordDedupeKey(r), r);
+  const merged = [...map.values()].sort(compareWalletTxTimeDesc);
+  const total = ra.total + rb.total;
+  const start = (page - 1) * size;
+  return { total, records: merged.slice(start, start + size) };
 };
 
 const transferTokenBetweenGroupAndUser: IWalletService['transferTokenBetweenGroupAndUser'] = async (
@@ -79,5 +107,6 @@ export const WalletServicesMock: IWalletService = {
   getUserWalletInfo,
   redeemVoucher,
   listTransactions,
+  listMergedTransactions,
   transferTokenBetweenGroupAndUser,
 };

--- a/src/services/Wallet/WalletServices.impl.ts
+++ b/src/services/Wallet/WalletServices.impl.ts
@@ -20,7 +20,24 @@ const toNum = (v: unknown, fallback = 0): number => {
   return Number.isFinite(n) ? n : fallback;
 };
 
+/** 部分网关/序列化会把枚举落成对象，统一取出可映射字段 */
+const normalizeTokenTransactionTypeRaw = (raw: unknown): unknown => {
+  if (raw == null) return raw;
+  if (typeof raw === 'object' && !Array.isArray(raw)) {
+    const o = raw as Record<string, unknown>;
+    return o.code ?? o.value ?? o.name ?? o.desc;
+  }
+  return raw;
+};
+
 const mapTokenTransactionTypeToKind = (raw: unknown, tokenCount: number): WalletTransactionKind => {
+  if (typeof raw === 'string') {
+    const upper = raw.trim().toUpperCase();
+    if (upper === 'REFILL') return 'RECHARGE';
+    if (upper === 'SPEND') return 'SPEND';
+    if (upper === 'TRANSFER_IN') return 'TRANSFER_IN';
+    if (upper === 'TRANSFER_OUT') return 'TRANSFER_OUT';
+  }
   const n = Number(raw);
   if (n === 1) return 'RECHARGE';
   if (n === 2) return 'SPEND';
@@ -46,12 +63,34 @@ const titleForKind = (k: WalletTransactionKind): string => {
   }
 };
 
+const operatorNameFromRow = (row: Record<string, unknown>): string | undefined => {
+  const direct =
+    row.operatorName != null && String(row.operatorName).trim().length > 0
+      ? String(row.operatorName)
+      : '';
+  if (direct) return direct;
+  const disp = row.operatorDisplay;
+  if (disp != null && typeof disp === 'object' && !Array.isArray(disp)) {
+    const o = disp as Record<string, unknown>;
+    const nick = o.nickname ?? o.nickName ?? o.userName ?? o.username;
+    if (nick != null && String(nick).trim().length > 0) return String(nick);
+  }
+  return undefined;
+};
+
 /** list 项：tokenTransactionType、tokenCount、meta、createTime 等 */
 const mapTransactionRow = (row: Record<string, unknown>): WalletTransactionRecord => {
   const amountNum = toNum(row.tokenCount ?? row.amount, 0);
-  const hasTxType = row.tokenTransactionType !== undefined && row.tokenTransactionType !== null;
+  const rawTx =
+    row.tokenTransactionType ??
+    row.TokenTransactionType ??
+    row.token_transaction_type ??
+    row.changeType;
+  const normalizedTx = normalizeTokenTransactionTypeRaw(rawTx);
+  const hasTxType =
+    normalizedTx !== undefined && normalizedTx !== null && String(normalizedTx) !== '';
   const kind = hasTxType
-    ? mapTokenTransactionTypeToKind(row.tokenTransactionType, amountNum)
+    ? mapTokenTransactionTypeToKind(normalizedTx, amountNum)
     : mapTokenTransactionTypeToKind(row.changeType, amountNum);
   const time = String(row.createTime ?? row.time ?? row.createdAt ?? '');
   const titleFromApi =
@@ -70,10 +109,7 @@ const mapTransactionRow = (row: Record<string, unknown>): WalletTransactionRecor
     amount: amountNum,
     title,
     subTitle,
-    operatorName:
-      row.operatorName != null && String(row.operatorName).trim().length > 0
-        ? String(row.operatorName)
-        : undefined,
+    operatorName: operatorNameFromRow(row),
   };
 };
 

--- a/src/services/Wallet/WalletServices.impl.ts
+++ b/src/services/Wallet/WalletServices.impl.ts
@@ -2,7 +2,7 @@
  * 钱包 Service：/user/wallet/*，成功码与全局一致 `code === 200`。
  */
 import Axios from '@/utils/Axios';
-import { WALLET_LIST_TX_TYPE_QUERY_VALUE } from '@/constants/wallet';
+import { WALLET_LIST_TX_TYPE_QUERY_VALUE, WALLET_TX_TAB_MERGE_FETCH_CAP } from '@/constants/wallet';
 import { checkResponse } from '@/utils/response';
 import type { ApiResponse } from '@/types/api';
 import type { WalletTransactionKind, WalletTransactionRecord } from '@/types/wallet';
@@ -11,6 +11,7 @@ import type {
   RedeemVoucherRequest,
   ListWalletTransactionsRequest,
   ListWalletTransactionsResponse,
+  ListMergedWalletTransactionsRequest,
   TransferTokenBetweenGroupAndUserRequest,
   IWalletService,
 } from './index.type';
@@ -165,6 +166,30 @@ const listTransactions = async (
   return { total: toNum(data.total, records.length), records };
 };
 
+const txRecordDedupeKey = (r: WalletTransactionRecord): string =>
+  r.traceId.length > 0 ? r.traceId : `${r.time}\u0000${r.type}\u0000${r.amount}`;
+
+const compareWalletTxTimeDesc = (a: WalletTransactionRecord, b: WalletTransactionRecord): number =>
+  String(b.time).localeCompare(String(a.time));
+
+const listMergedTransactions = async (
+  params: ListMergedWalletTransactionsRequest
+): Promise<ListWalletTransactionsResponse> => {
+  const { groupId, page = 1, size = 20, typeA, typeB } = params;
+  const cap = WALLET_TX_TAB_MERGE_FETCH_CAP;
+  const [ra, rb] = await Promise.all([
+    listTransactions({ groupId, page: 1, size: cap, type: typeA }),
+    listTransactions({ groupId, page: 1, size: cap, type: typeB }),
+  ]);
+  const map = new Map<string, WalletTransactionRecord>();
+  for (const r of ra.records) map.set(txRecordDedupeKey(r), r);
+  for (const r of rb.records) map.set(txRecordDedupeKey(r), r);
+  const merged = [...map.values()].sort(compareWalletTxTimeDesc);
+  const total = ra.total + rb.total;
+  const start = (page - 1) * size;
+  return { total, records: merged.slice(start, start + size) };
+};
+
 const transferTokenBetweenGroupAndUser = async (
   params: TransferTokenBetweenGroupAndUserRequest
 ): Promise<void> => {
@@ -180,5 +205,6 @@ export const WalletServicesImpl: IWalletService = {
   getUserWalletInfo,
   redeemVoucher,
   listTransactions,
+  listMergedTransactions,
   transferTokenBetweenGroupAndUser,
 };

--- a/src/services/Wallet/index.ts
+++ b/src/services/Wallet/index.ts
@@ -6,4 +6,5 @@ export type {
   TransferTokenBetweenGroupAndUserRequest,
   ListWalletTransactionsRequest,
   ListWalletTransactionsResponse,
+  ListMergedWalletTransactionsRequest,
 } from './index.type';

--- a/src/services/Wallet/index.type.ts
+++ b/src/services/Wallet/index.type.ts
@@ -37,9 +37,24 @@ export interface ListWalletTransactionsResponse {
   records: WalletTransactionRecord[];
 }
 
+/**
+ * 并行拉两类流水、合并去重后按时间倒序再本地分页（每类先取 page=1、size 见 WALLET_TX_TAB_MERGE_FETCH_CAP）。
+ * typeA/typeB 与 WALLET_TOKEN_TX_TYPE 数值一致。
+ */
+export interface ListMergedWalletTransactionsRequest {
+  groupId?: string | number | null;
+  page?: number;
+  size?: number;
+  typeA: number;
+  typeB: number;
+}
+
 export interface IWalletService {
   getUserWalletInfo(): Promise<GetWalletInfoResponse>;
   redeemVoucher(params: RedeemVoucherRequest): Promise<void>;
   listTransactions(params: ListWalletTransactionsRequest): Promise<ListWalletTransactionsResponse>;
+  listMergedTransactions(
+    params: ListMergedWalletTransactionsRequest
+  ): Promise<ListWalletTransactionsResponse>;
   transferTokenBetweenGroupAndUser(params: TransferTokenBetweenGroupAndUserRequest): Promise<void>;
 }


### PR DESCRIPTION
- 新增 listMergedTransactions 与 ListMergedWalletTransactionsRequest
- ComputeWallet 消费/小组充值 Tab 改为调用 Service
- Mock 对齐接口并补充 type 3/4 筛选