### PR TITLE
refactor(services): 工厂化装配 + Tag/Folder 语义边界收敛

### DIFF
--- a/src/components/Drive/FlatDrive/FileFilter/AddStickerModal/index.tsx
+++ b/src/components/Drive/FlatDrive/FileFilter/AddStickerModal/index.tsx
@@ -4,6 +4,7 @@ import { useRequest } from 'ahooks';
 import { useStickerService } from '@/contexts/ServicesContext';
 import { useAppMessage } from '@/hooks/useAppMessage';
 import { parseErrorMessage } from '@/utils/parseErrorMessage';
+import { validateReservedName } from '@/utils/validateReservedName';
 import type { AddStickerModalProps } from './index.type';
 
 const AddStickerModal: React.FC<AddStickerModalProps> = ({ open, onCancel, onSuccess }) => {
@@ -38,8 +39,13 @@ const AddStickerModal: React.FC<AddStickerModalProps> = ({ open, onCancel, onSuc
   const handleOk = useCallback(async () => {
     const trimmed = name.trim();
     if (!trimmed) return;
+    const validation = validateReservedName(trimmed);
+    if (!validation.valid) {
+      message.warning(validation.reason);
+      return;
+    }
     runAddSticker(trimmed);
-  }, [name, runAddSticker]);
+  }, [name, runAddSticker, message]);
 
   return (
     <Modal

--- a/src/components/Drive/Modals/NewFolderModal/index.tsx
+++ b/src/components/Drive/Modals/NewFolderModal/index.tsx
@@ -4,6 +4,7 @@ import { Modal, Button, Input } from 'antd';
 import { useFolderService } from '@/contexts/ServicesContext';
 import { parseErrorMessage } from '@/utils/parseErrorMessage';
 import { getFolderDisplayName } from '@/utils/path';
+import { validateReservedName } from '@/utils/validateReservedName';
 import type { NewFolderModalProps } from './index.type';
 import { useAppMessage } from '@/hooks/useAppMessage';
 
@@ -44,6 +45,11 @@ const NewFolderModal: React.FC<NewFolderModalProps> = ({
     const trimmed = name.trim();
     if (!trimmed) {
       message.warning('请输入文件夹名称');
+      return;
+    }
+    const validation = validateReservedName(trimmed);
+    if (!validation.valid) {
+      message.warning(validation.reason);
       return;
     }
     if (!parentFolder) {

--- a/src/components/Drive/Modals/NewTagModal/index.tsx
+++ b/src/components/Drive/Modals/NewTagModal/index.tsx
@@ -3,6 +3,7 @@ import { Modal, Button, Input } from 'antd';
 import { useRequest } from 'ahooks';
 import { useTagService } from '@/contexts/ServicesContext';
 import { parseErrorMessage } from '@/utils/parseErrorMessage';
+import { validateReservedName } from '@/utils/validateReservedName';
 import type { NewTagModalProps } from './index.type';
 import { useAppMessage } from '@/hooks/useAppMessage';
 
@@ -50,6 +51,11 @@ const NewTagModal: React.FC<NewTagModalProps> = ({
     const trimmed = name.trim();
     if (!trimmed) {
       message.warning(`请输入${subjectLabel}名称`);
+      return;
+    }
+    const validation = validateReservedName(trimmed);
+    if (!validation.valid) {
+      message.warning(validation.reason);
       return;
     }
     runAddTag(trimmed);

--- a/src/contexts/ServicesContext/hooks.ts
+++ b/src/contexts/ServicesContext/hooks.ts
@@ -27,17 +27,17 @@ function useServicesContext(): ServicesContextValue {
 }
 
 // 第七步：导出 useXxxService hook，组件内通过 useOrderService() 等获取实例
-export const useAuthService = (): IAuthService => useServicesContext().auth;
-export const useChatService = (): IChatService => useServicesContext().chat;
-export const useDocumentService = (): IDocumentService => useServicesContext().document;
-export const useFolderService = (): IFolderService => useServicesContext().folder;
-export const useGroupService = (): IGroupService => useServicesContext().group;
-export const useImageService = (): IImageService => useServicesContext().image;
-export const useNoteService = (): INoteService => useServicesContext().note;
-export const useQuotaService = (): IQuotaService => useServicesContext().quota;
-export const useResourceService = (): IResourceService => useServicesContext().resource;
-export const useStickerService = (): IStickerService => useServicesContext().sticker;
-export const useTagService = (): ITagService => useServicesContext().tag;
-export const useUserService = (): IUserService => useServicesContext().user;
+export const useAuthService = (): IAuthService => useServicesContext().authService;
+export const useChatService = (): IChatService => useServicesContext().chatService;
+export const useDocumentService = (): IDocumentService => useServicesContext().documentService;
+export const useFolderService = (): IFolderService => useServicesContext().folderService;
+export const useGroupService = (): IGroupService => useServicesContext().groupService;
+export const useImageService = (): IImageService => useServicesContext().imageService;
+export const useNoteService = (): INoteService => useServicesContext().noteService;
+export const useQuotaService = (): IQuotaService => useServicesContext().quotaService;
+export const useResourceService = (): IResourceService => useServicesContext().resourceService;
+export const useStickerService = (): IStickerService => useServicesContext().stickerService;
+export const useTagService = (): ITagService => useServicesContext().tagService;
+export const useUserService = (): IUserService => useServicesContext().userService;
 /** 个人中心钱包、高级组 token 相关页注入 */
-export const useWalletService = (): IWalletService => useServicesContext().wallet;
+export const useWalletService = (): IWalletService => useServicesContext().walletService;

--- a/src/contexts/ServicesContext/registry.impl.ts
+++ b/src/contexts/ServicesContext/registry.impl.ts
@@ -1,36 +1,62 @@
 /**
- * 真实服务注册表：仅绑定 *Services.impl.ts
+ * 真实服务注册表：Service 依赖装配入口
+ *
+ * 统一形态：每个 *Services.impl.ts 均导出 createXxxServices(deps?): IXxxService 工厂。
+ *
+ * 装配规则：
+ * - Level 0：无跨 service 依赖，工厂无参。
+ * - Level 1：依赖 Level 0，通过参数注入依赖后构建。
+ *
+ * 为避免循环依赖与隐式耦合，service 间不得互相直接 import 实现，必须经此装配。
+ * 新增更深层级（Level 2+）时在此文件延展，保持"分层 + 显式注入"。
  */
-import { AuthServicesImpl } from '@/services/Auth/AuthServices.impl';
-import { ChatServicesImpl } from '@/services/Chat/ChatServices.impl';
-import { DocumentServicesImpl } from '@/services/Document/DocumentServices.impl';
-import { FolderServicesImpl } from '@/services/Folder/FolderServices.impl';
-import { GroupServicesImpl } from '@/services/Group/GroupServices.impl';
-import { ImageServicesImpl } from '@/services/Image/ImageServices.impl';
-import { NoteServicesImpl } from '@/services/Note/NoteServices.impl';
-import { QuotaServicesImpl } from '@/services/Quota/QuotaServices.impl';
-import { ResourceServicesImpl } from '@/services/Resource/ResourceServices.impl';
-import { StickerServicesImpl } from '@/services/Sticker/StickerServices.impl';
-import { TagServicesImpl } from '@/services/Tag/TagServices.impl';
-import { UserServicesImpl } from '@/services/User/UserServices.impl';
-import { WalletServicesImpl } from '@/services/Wallet/WalletServices.impl';
+import { createAuthServices } from '@/services/Auth/AuthServices.impl';
+import { createChatServices } from '@/services/Chat/ChatServices.impl';
+import { createDocumentServices } from '@/services/Document/DocumentServices.impl';
+import { createFolderServices } from '@/services/Folder/FolderServices.impl';
+import { createGroupServices } from '@/services/Group/GroupServices.impl';
+import { createImageServices } from '@/services/Image/ImageServices.impl';
+import { createNoteServices } from '@/services/Note/NoteServices.impl';
+import { createQuotaServices } from '@/services/Quota/QuotaServices.impl';
+import { createResourceServices } from '@/services/Resource/ResourceServices.impl';
+import { createStickerServices } from '@/services/Sticker/StickerServices.impl';
+import { createTagServices } from '@/services/Tag/TagServices.impl';
+import { createUserServices } from '@/services/User/UserServices.impl';
+import { createWalletServices } from '@/services/Wallet/WalletServices.impl';
 
 import type { ServicesContextValue } from './registry.types';
 
+// Level 0：无跨 service 依赖
+const authService = createAuthServices();
+const chatService = createChatServices();
+const documentService = createDocumentServices();
+const groupService = createGroupServices();
+const imageService = createImageServices();
+const noteService = createNoteServices();
+const quotaService = createQuotaServices();
+const resourceService = createResourceServices();
+const userService = createUserServices();
+const walletService = createWalletServices();
+
+// Level 1：依赖 Level 0
+const tagService = createTagServices({ resourceService: resourceService });
+const stickerService = createStickerServices({ resourceService: resourceService });
+const folderService = createFolderServices({ resourceService: resourceService });
+
 const servicesValue: ServicesContextValue = {
-  auth: AuthServicesImpl,
-  chat: ChatServicesImpl,
-  document: DocumentServicesImpl,
-  folder: FolderServicesImpl,
-  group: GroupServicesImpl,
-  image: ImageServicesImpl,
-  note: NoteServicesImpl,
-  quota: QuotaServicesImpl,
-  resource: ResourceServicesImpl,
-  sticker: StickerServicesImpl,
-  tag: TagServicesImpl,
-  user: UserServicesImpl,
-  wallet: WalletServicesImpl,
+  authService: authService,
+  chatService: chatService,
+  documentService: documentService,
+  folderService: folderService,
+  groupService: groupService,
+  imageService: imageService,
+  noteService: noteService,
+  quotaService: quotaService,
+  resourceService: resourceService,
+  stickerService: stickerService,
+  tagService: tagService,
+  userService: userService,
+  walletService: walletService,
 };
 
 export function getContextValue(): ServicesContextValue {

--- a/src/contexts/ServicesContext/registry.mock.ts
+++ b/src/contexts/ServicesContext/registry.mock.ts
@@ -18,19 +18,19 @@ import { WalletServicesMock } from '@/mocks/Wallet/WalletServices.mock';
 import type { ServicesContextValue } from './registry.types';
 
 const mockServicesValue: ServicesContextValue = {
-  auth: AuthServicesMock,
-  chat: ChatServicesMock,
-  document: DocumentServicesMock,
-  folder: FolderServicesMock,
-  group: GroupServicesMock,
-  image: ImageServicesMock,
-  note: NoteServicesMock,
-  quota: QuotaServicesMock,
-  resource: ResourceServicesMock,
-  sticker: StickerServicesMock,
-  tag: TagServicesMock,
-  user: UserServicesMock,
-  wallet: WalletServicesMock,
+  authService: AuthServicesMock,
+  chatService: ChatServicesMock,
+  documentService: DocumentServicesMock,
+  folderService: FolderServicesMock,
+  groupService: GroupServicesMock,
+  imageService: ImageServicesMock,
+  noteService: NoteServicesMock,
+  quotaService: QuotaServicesMock,
+  resourceService: ResourceServicesMock,
+  stickerService: StickerServicesMock,
+  tagService: TagServicesMock,
+  userService: UserServicesMock,
+  walletService: WalletServicesMock,
 };
 
 export function getContextValue(): ServicesContextValue {

--- a/src/contexts/ServicesContext/registry.types.ts
+++ b/src/contexts/ServicesContext/registry.types.ts
@@ -14,18 +14,17 @@ import type { IUserService } from '@/services/User';
 import type { IWalletService } from '@/services/Wallet';
 
 export interface ServicesContextValue {
-  auth: IAuthService;
-  chat: IChatService;
-  document: IDocumentService;
-  folder: IFolderService;
-  group: IGroupService;
-  image: IImageService;
-  note: INoteService;
-  quota: IQuotaService;
-  resource: IResourceService;
-  sticker: IStickerService;
-  tag: ITagService;
-  user: IUserService;
-  /** 见 src/services/Wallet */
-  wallet: IWalletService;
+  authService: IAuthService;
+  chatService: IChatService;
+  documentService: IDocumentService;
+  folderService: IFolderService;
+  groupService: IGroupService;
+  imageService: IImageService;
+  noteService: INoteService;
+  quotaService: IQuotaService;
+  resourceService: IResourceService;
+  stickerService: IStickerService;
+  tagService: ITagService;
+  userService: IUserService;
+  walletService: IWalletService;
 }

--- a/src/services/Auth/AuthServices.impl.ts
+++ b/src/services/Auth/AuthServices.impl.ts
@@ -42,10 +42,10 @@ const newPassword = async (params: NewPasswordRequest) => {
   checkResponse(res);
 };
 
-export const AuthServicesImpl: IAuthService = {
+export const createAuthServices = (): IAuthService => ({
   login,
   register,
   resetPassword,
   newPassword,
   logout,
-};
+});

--- a/src/services/Chat/ChatServices.impl.ts
+++ b/src/services/Chat/ChatServices.impl.ts
@@ -108,11 +108,11 @@ const listHistoryMessages = async (
   };
 };
 
-export const ChatServicesImpl: IChatService = {
+export const createChatServices = (): IChatService => ({
   getModels,
   createSession,
   renameSession,
   deleteSession,
   listSessions,
   listHistoryMessages,
-};
+});

--- a/src/services/Document/DocumentServices.impl.ts
+++ b/src/services/Document/DocumentServices.impl.ts
@@ -151,7 +151,7 @@ const getDocInfo = async (resourceId: string): Promise<DocDisplayInfoResponse> =
   checkResponse(res);
   return res.data;
 };
-export const DocumentServicesImpl: IDocumentService = {
+export const createDocumentServices = (): IDocumentService => ({
   uploadDocument,
   retryConvert,
   deleteDocument,
@@ -160,4 +160,4 @@ export const DocumentServicesImpl: IDocumentService = {
   retryPendingDoc,
   cancelPendingDoc,
   getDocInfo,
-};
+});

--- a/src/services/Folder/FolderServices.impl.ts
+++ b/src/services/Folder/FolderServices.impl.ts
@@ -6,18 +6,34 @@ import type { TagTreeResponse } from '@/services/Tag/index.type';
 import Axios from '@/utils/Axios';
 import { normalizeTagGroupId } from '@/utils/normalizeTagGroupId';
 import { checkResponse } from '@/utils/response';
-import { ResourceServicesImpl } from '@/services/Resource/ResourceServices.impl';
+import type { IResourceService } from '@/services/Resource/index.type';
 import { RESOURCE_SORT_BY, RESOURCE_SORT_DIR } from '@/services/Resource/index.type';
-import { TagServicesImpl } from '@/services/Tag/TagServices.impl';
 import { useTrashTagStore } from '@/store';
 import { registerServiceCacheCleaner } from '@/services/cacheRegistry';
 import type { IFolderService, GetResByFolderRequest, GetFolderTreeRequest } from './index.type';
 
-/** 模块级缓存，按 groupId 存储已拉取的文件夹树；写操作后通过 clearFolderTreeCache 清除 */
-const folderTreeCache = new Map<string, Folder>();
-/** 扁平索引：cacheKey → (tagId → Folder)，与 folderTreeCache 同步维护 */
-const folderFlatCache = new Map<string, Map<string, Folder>>();
 const CACHE_KEY_DEFAULT = '__default__';
+/** 回收站节点名：与 `/` 同级的根节点之一，由 Folder 域负责识别与维护 */
+const TRASH_FOLDER_NAME = '.Trash';
+
+/** 在原始 tag 树中查找 `.Trash` 节点，并将其 tagId 同步到 trash store */
+const syncTrashTagIdToStore = (groupId: string | undefined, roots: TagTreeResponse[]): void => {
+  const queue: TagTreeResponse[] = [...roots];
+  while (queue.length > 0) {
+    const node = queue.shift();
+    if (!node) {
+      continue;
+    }
+    if (node.tagName === TRASH_FOLDER_NAME) {
+      useTrashTagStore.getState().setTrashTagId(groupId, node.tagId);
+      return;
+    }
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      queue.push(...node.children);
+    }
+  }
+  useTrashTagStore.getState().setTrashTagId(groupId, undefined);
+};
 
 const buildFlatMap = (root: Folder): Map<string, Folder> => {
   const map = new Map<string, Folder>();
@@ -29,159 +45,179 @@ const buildFlatMap = (root: Folder): Map<string, Folder> => {
   return map;
 };
 
-const getFolderTree = async (params: GetFolderTreeRequest = {}): Promise<Folder> => {
-  const normalizedGroupId = normalizeTagGroupId(params.groupId);
-  const cacheKey = normalizedGroupId ?? CACHE_KEY_DEFAULT;
-  const cached = folderTreeCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-  const res = (await Axios.get('/resource/tag/getTagTree', {
-    params: normalizedGroupId ? { groupId: normalizedGroupId } : undefined,
-  })) as ApiResponse<TagTreeResponse[]>;
-  checkResponse(res);
-  const tags = res.data ?? [];
-  const rootTag = tags.find((tag) => tag.tagName === '/');
-  if (!rootTag) {
-    throw new Error('未能加载根文件夹');
-  }
-  const root = mapTagToFolder(rootTag) as Folder;
-  folderTreeCache.set(cacheKey, root);
-  folderFlatCache.set(cacheKey, buildFlatMap(root));
-  return root;
-};
+export interface FolderServicesDeps {
+  resourceService: IResourceService;
+}
 
-const getFolderById = (tagId: string, groupId?: string): Folder | undefined => {
-  const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
-  return folderFlatCache.get(cacheKey)?.get(tagId);
-};
+export const createFolderServices = (deps: FolderServicesDeps): IFolderService => {
+  const { resourceService } = deps;
 
-const clearFolderTreeCache = (groupId?: string): void => {
-  if (groupId !== undefined) {
-    const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
-    folderTreeCache.delete(cacheKey);
-    folderFlatCache.delete(cacheKey);
-  } else {
-    folderTreeCache.clear();
-    folderFlatCache.clear();
-  }
-};
+  /** 按 groupId 存储已拉取的文件夹树；写操作后通过 clearFolderTreeCache 清除 */
+  const folderTreeCache = new Map<string, Folder>();
+  /** 扁平索引：cacheKey → (tagId → Folder)，与 folderTreeCache 同步维护 */
+  const folderFlatCache = new Map<string, Map<string, Folder>>();
 
-registerServiceCacheCleaner(() => clearFolderTreeCache());
-
-// 返回一个节点下的所有子节点和文件
-const getResByFolder = async (params: GetResByFolderRequest): Promise<FolderListByPathResponse> => {
-  const targetFolder = params.folder;
-  await getFolderTree({ groupId: targetFolder.groupId });
-  const folder = getFolderById(targetFolder.tagId, targetFolder.groupId);
-  const folders = folder?.children ?? [];
-  const filePage = params.filePage ?? 1;
-  const filePageSize = params.filePageSize ?? 20;
-  const tagId = targetFolder.tagId;
-
-  let files: ResourceItem[] = [];
-  let totalFiles = 0;
-
-  const listParams = {
-    page: filePage,
-    size: filePageSize,
-    sortBy: RESOURCE_SORT_BY.UPDATE_TIME,
-    sortDir: RESOURCE_SORT_DIR.DESC,
-    tagIds: [tagId],
-    tagQueryLogicMode: 'AND' as const,
-  };
-  const normalizedGroupId = normalizeTagGroupId(targetFolder.groupId);
-  const res = normalizedGroupId
-    ? await ResourceServicesImpl.getGroupResources({ ...listParams, groupId: normalizedGroupId })
-    : await ResourceServicesImpl.getUserResources(listParams);
-
-  files = res.list;
-  totalFiles = res.total;
-
-  return { folders, files, totalFiles };
-};
-
-const renameFolder = async (folder: Folder, newName: string): Promise<void> => {
-  const newPathName = '/' + newName;
-  const res = (await Axios.post('/resource/tag/changeTag', {
-    targetTagId: folder.tagId,
-    tagName: newPathName,
-  })) as ApiResponse;
-  checkResponse(res);
-  clearFolderTreeCache(folder.groupId);
-};
-
-const deleteFolder = async (folder: Folder): Promise<void> => {
-  let trashTagId = useTrashTagStore.getState().getTrashTagId(folder.groupId);
-  if (!trashTagId) {
-    await TagServicesImpl.getTagTree(folder.groupId);
-    trashTagId = useTrashTagStore.getState().getTrashTagId(folder.groupId);
-  }
-  if (!trashTagId) {
-    throw new Error('未找到回收站标签，无法删除文件夹');
-  }
-
-  const res = (await Axios.post('/resource/tag/moveTag', {
-    targetTagId: folder.tagId,
-    newParentId: trashTagId,
-  })) as ApiResponse;
-  checkResponse(res);
-  clearFolderTreeCache(folder.groupId);
-};
-
-const createFolder = async (parentFolder: Folder, folderName: string): Promise<void> => {
-  const newPathName = `/${folderName}`;
-  const res = (await Axios.post('/resource/tag/addTag', {
-    parentId: parentFolder.tagId,
-    tagName: newPathName,
-  })) as ApiResponse;
-  console.log(parentFolder, folderName, res);
-  checkResponse(res);
-  clearFolderTreeCache();
-};
-
-const moveFolderToFolder = async (folder: Folder, newParentFolder: Folder): Promise<void> => {
-  // 遍历 newParentFolder 的父链，防止循环移动
-  let current: Folder | undefined = newParentFolder;
-  while (current) {
-    if (current.tagId === folder.tagId) {
-      throw new Error('不能将文件夹移动到自身或其子目录下');
+  const clearFolderTreeCache = (groupId?: string): void => {
+    if (groupId !== undefined) {
+      const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
+      folderTreeCache.delete(cacheKey);
+      folderFlatCache.delete(cacheKey);
+    } else {
+      folderTreeCache.clear();
+      folderFlatCache.clear();
     }
-    // folder.groupId 可选，不一定有，所以调用 getFolderById 时带 groupId
-    if (!current.parentId) break;
-    current = getFolderById(current.parentId, current.groupId);
-  }
-  const res = (await Axios.post('/resource/tag/moveTag', {
-    targetTagId: folder.tagId,
-    newParentId: newParentFolder.tagId,
-  })) as ApiResponse;
-  checkResponse(res);
-  clearFolderTreeCache();
-};
+  };
 
-const moveResourceToFolder = async (folder: Folder, resource: ResourceItem): Promise<void> => {
-  const currentTags = resource.currentTags ?? {};
-  // 过滤出非文件夹标签，保留
-  const nonFolderTagIds = Object.entries(currentTags)
-    .filter(([, tagName]) => !tagName.startsWith('/'))
-    .map(([tagId]) => tagId);
-  // 构造新的标签列表
-  const newTagIds = [...nonFolderTagIds, folder.tagId];
+  registerServiceCacheCleaner(() => clearFolderTreeCache());
 
-  await ResourceServicesImpl.updateResourceTags({
-    resourceId: resource.resourceId,
-    tagIds: newTagIds,
-  });
-  clearFolderTreeCache();
-};
+  const getFolderTree = async (params: GetFolderTreeRequest = {}): Promise<Folder> => {
+    const normalizedGroupId = normalizeTagGroupId(params.groupId);
+    const cacheKey = normalizedGroupId ?? CACHE_KEY_DEFAULT;
+    const cached = folderTreeCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const res = (await Axios.get('/resource/tag/getTagTree', {
+      params: normalizedGroupId ? { groupId: normalizedGroupId } : undefined,
+    })) as ApiResponse<TagTreeResponse[]>;
+    checkResponse(res);
+    const tags = res.data ?? [];
+    // `.Trash` 与 `/` 同级，属于 Folder 域；拉树时顺带同步 trashTagId
+    syncTrashTagIdToStore(normalizedGroupId, tags);
+    const rootTag = tags.find((t) => t.tagName === '/');
+    if (!rootTag) {
+      throw new Error('未能加载根文件夹');
+    }
+    const root = mapTagToFolder(rootTag) as Folder;
+    folderTreeCache.set(cacheKey, root);
+    folderFlatCache.set(cacheKey, buildFlatMap(root));
+    return root;
+  };
 
-export const FolderServicesImpl: IFolderService = {
-  getFolderTree,
-  getFolderById,
-  getResByFolder,
-  renameFolder,
-  deleteFolder,
-  createFolder,
-  moveFolderToFolder,
-  moveResourceToFolder,
+  const getFolderById = (tagId: string, groupId?: string): Folder | undefined => {
+    const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
+    return folderFlatCache.get(cacheKey)?.get(tagId);
+  };
+
+  // 返回一个节点下的所有子节点和文件
+  const getResByFolder = async (
+    params: GetResByFolderRequest
+  ): Promise<FolderListByPathResponse> => {
+    const targetFolder = params.folder;
+    await getFolderTree({ groupId: targetFolder.groupId });
+    const folder = getFolderById(targetFolder.tagId, targetFolder.groupId);
+    const folders = folder?.children ?? [];
+    const filePage = params.filePage ?? 1;
+    const filePageSize = params.filePageSize ?? 20;
+    const tagId = targetFolder.tagId;
+
+    let files: ResourceItem[] = [];
+    let totalFiles = 0;
+
+    const listParams = {
+      page: filePage,
+      size: filePageSize,
+      sortBy: RESOURCE_SORT_BY.UPDATE_TIME,
+      sortDir: RESOURCE_SORT_DIR.DESC,
+      tagIds: [tagId],
+      tagQueryLogicMode: 'AND' as const,
+    };
+    const normalizedGroupId = normalizeTagGroupId(targetFolder.groupId);
+    const res = normalizedGroupId
+      ? await resourceService.getGroupResources({ ...listParams, groupId: normalizedGroupId })
+      : await resourceService.getUserResources(listParams);
+
+    files = res.list;
+    totalFiles = res.total;
+
+    return { folders, files, totalFiles };
+  };
+
+  const renameFolder = async (folder: Folder, newName: string): Promise<void> => {
+    const newPathName = '/' + newName;
+    const res = (await Axios.post('/resource/tag/changeTag', {
+      targetTagId: folder.tagId,
+      tagName: newPathName,
+    })) as ApiResponse;
+    checkResponse(res);
+    clearFolderTreeCache(folder.groupId);
+  };
+
+  const deleteFolder = async (folder: Folder): Promise<void> => {
+    let trashTagId = useTrashTagStore.getState().getTrashTagId(folder.groupId);
+    if (!trashTagId) {
+      // trash store 未填充时拉一次本域 folder 树，顺带同步 trashTagId
+      await getFolderTree({ groupId: folder.groupId });
+      trashTagId = useTrashTagStore.getState().getTrashTagId(folder.groupId);
+    }
+    if (!trashTagId) {
+      throw new Error('未找到回收站标签，无法删除文件夹');
+    }
+
+    const res = (await Axios.post('/resource/tag/moveTag', {
+      targetTagId: folder.tagId,
+      newParentId: trashTagId,
+    })) as ApiResponse;
+    checkResponse(res);
+    clearFolderTreeCache(folder.groupId);
+  };
+
+  const createFolder = async (parentFolder: Folder, folderName: string): Promise<void> => {
+    const newPathName = `/${folderName}`;
+    const res = (await Axios.post('/resource/tag/addTag', {
+      parentId: parentFolder.tagId,
+      tagName: newPathName,
+    })) as ApiResponse;
+    checkResponse(res);
+    clearFolderTreeCache();
+  };
+
+  const moveFolderToFolder = async (folder: Folder, newParentFolder: Folder): Promise<void> => {
+    // 遍历 newParentFolder 的父链，防止循环移动
+    let current: Folder | undefined = newParentFolder;
+    while (current) {
+      if (current.tagId === folder.tagId) {
+        throw new Error('不能将文件夹移动到自身或其子目录下');
+      }
+      // folder.groupId 可选，不一定有，所以调用 getFolderById 时带 groupId
+      if (!current.parentId) break;
+      current = getFolderById(current.parentId, current.groupId);
+    }
+    const res = (await Axios.post('/resource/tag/moveTag', {
+      targetTagId: folder.tagId,
+      newParentId: newParentFolder.tagId,
+    })) as ApiResponse;
+    checkResponse(res);
+    clearFolderTreeCache();
+  };
+
+  const moveResourceToFolder = async (
+    folder: Folder,
+    resourceItem: ResourceItem
+  ): Promise<void> => {
+    const currentTags = resourceItem.currentTags ?? {};
+    // 过滤出非文件夹标签，保留
+    const nonFolderTagIds = Object.entries(currentTags)
+      .filter(([, tagName]) => !tagName.startsWith('/'))
+      .map(([tagId]) => tagId);
+    // 构造新的标签列表
+    const newTagIds = [...nonFolderTagIds, folder.tagId];
+
+    await resourceService.updateResourceTags({
+      resourceId: resourceItem.resourceId,
+      tagIds: newTagIds,
+    });
+    clearFolderTreeCache();
+  };
+
+  return {
+    getFolderTree,
+    getFolderById,
+    getResByFolder,
+    renameFolder,
+    deleteFolder,
+    createFolder,
+    moveFolderToFolder,
+    moveResourceToFolder,
+  };
 };

--- a/src/services/Group/GroupServices.impl.ts
+++ b/src/services/Group/GroupServices.impl.ts
@@ -165,7 +165,7 @@ const kickMembers = async (params: KickMembersRequest) => {
   checkResponse(res);
 };
 
-export const GroupServicesImpl: IGroupService = {
+export const createGroupServices = (): IGroupService => ({
   fetchGroupList,
   fetchGroupInfo,
   getGroupWalletInfo,
@@ -180,4 +180,4 @@ export const GroupServicesImpl: IGroupService = {
   quitGroup,
   updateMemberRole,
   kickMembers,
-};
+});

--- a/src/services/Image/ImageServices.impl.ts
+++ b/src/services/Image/ImageServices.impl.ts
@@ -34,6 +34,6 @@ const uploadImage = async (params: ImageUploadRequest): Promise<ImageUploadResul
   };
 };
 
-export const ImageServicesImpl: IImageService = {
+export const createImageServices = (): IImageService => ({
   uploadImage,
-};
+});

--- a/src/services/Note/NoteServices.impl.ts
+++ b/src/services/Note/NoteServices.impl.ts
@@ -60,9 +60,9 @@ const getNoteInfoDisplay = async (params: GetNoteInfoRequest): Promise<NoteInfoD
   };
 };
 
-export const NoteServicesImpl: INoteService = {
+export const createNoteServices = (): INoteService => ({
   syncTitle,
   createNote,
   deleteNote,
   getNoteInfoDisplay,
-};
+});

--- a/src/services/Quota/QuotaServices.impl.ts
+++ b/src/services/Quota/QuotaServices.impl.ts
@@ -62,8 +62,8 @@ const setGroupQuota = async (params: SetGroupQuotaRequest) => {
   checkResponse(res);
 };
 
-export const QuotaServicesImpl: IQuotaService = {
+export const createQuotaServices = (): IQuotaService => ({
   fetchUserGroupQuotas,
   fetchGroupQuota,
   setGroupQuota,
-};
+});

--- a/src/services/Resource/ResourceServices.impl.ts
+++ b/src/services/Resource/ResourceServices.impl.ts
@@ -73,10 +73,10 @@ const updateResourceTags = async (params: UpdateResourceTagsRequest): Promise<vo
   checkResponse(res);
 };
 
-export const ResourceServicesImpl: IResourceService = {
+export const createResourceServices = (): IResourceService => ({
   getUserResources,
   getGroupResources,
   renameResource,
   updateResourcePath,
   updateResourceTags,
-};
+});

--- a/src/services/Sticker/StickerServices.impl.ts
+++ b/src/services/Sticker/StickerServices.impl.ts
@@ -1,8 +1,7 @@
-import { TagServicesImpl } from '@/services/Tag/TagServices.impl';
-import { ResourceServicesImpl } from '@/services/Resource/ResourceServices.impl';
 import Axios from '@/utils/Axios';
 import { checkResponse } from '@/utils/response';
 import type { ApiResponse } from '@/types/api';
+import type { IResourceService } from '@/services/Resource/index.type';
 import type { TagTreeResponse } from '@/services/Tag/index.type';
 import type {
   IStickerService,
@@ -13,49 +12,60 @@ import type {
   UpdateResourceStickersRequest,
 } from './index.type';
 
-const getStickerList = async (): Promise<Sticker[]> => {
-  const res = (await Axios.get('/resource/tag/getTagTree')) as ApiResponse<TagTreeResponse[]>;
-  checkResponse(res);
-  // 过滤掉路径标签, 忽略叶子节点，同时简化数据结构
-  const stickers = res.data
-    .filter((node) => node.tagName !== '/' && node.tagName !== '.Trash')
-    .map((node) => ({ tagId: node.tagId, tagName: node.tagName }));
-  return stickers;
-};
+export interface StickerServicesDeps {
+  resourceService: IResourceService;
+}
 
-const addSticker = async (params: AddStickerRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/addTag', {
-    tagName: params.stickerName,
-  })) as ApiResponse;
-  checkResponse(res);
-};
+export const createStickerServices = (deps: StickerServicesDeps): IStickerService => {
+  const { resourceService } = deps;
 
-const updateSticker = async (params: UpdateStickerRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/changeTag', {
-    targetTagId: params.stickerId,
-    tagName: params.stickerName,
-  })) as ApiResponse;
-  checkResponse(res);
-};
+  const getStickerList = async (): Promise<Sticker[]> => {
+    const res = (await Axios.get('/resource/tag/getTagTree')) as ApiResponse<TagTreeResponse[]>;
+    checkResponse(res);
+    // 过滤掉路径型（`/` 开头）与系统保留前缀（`.` 开头，例如 `.Trash`）
+    const stickers = (res.data ?? [])
+      .filter((node) => {
+        const name = node.tagName ?? '';
+        return name !== '' && !name.startsWith('/') && !name.startsWith('.');
+      })
+      .map((node) => ({ tagId: node.tagId, tagName: node.tagName }));
+    return stickers;
+  };
 
-const deleteSticker = async (params: DeleteStickerRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/removeTag', {
-    targetTagId: params.stickerId,
-  })) as ApiResponse;
-  checkResponse(res);
-};
+  const addSticker = async (params: AddStickerRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/addTag', {
+      tagName: params.stickerName,
+    })) as ApiResponse;
+    checkResponse(res);
+  };
 
-const updateResourceStickers = async (params: UpdateResourceStickersRequest): Promise<void> => {
-  await ResourceServicesImpl.updateResourceTags({
-    resourceId: params.resourceId,
-    tagIds: params.stickerIds,
-  });
-};
+  const updateSticker = async (params: UpdateStickerRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/changeTag', {
+      targetTagId: params.stickerId,
+      tagName: params.stickerName,
+    })) as ApiResponse;
+    checkResponse(res);
+  };
 
-export const StickerServicesImpl: IStickerService = {
-  getStickerList,
-  addSticker,
-  updateSticker,
-  deleteSticker,
-  updateResourceStickers,
+  const deleteSticker = async (params: DeleteStickerRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/removeTag', {
+      targetTagId: params.stickerId,
+    })) as ApiResponse;
+    checkResponse(res);
+  };
+
+  const updateResourceStickers = async (params: UpdateResourceStickersRequest): Promise<void> => {
+    await resourceService.updateResourceTags({
+      resourceId: params.resourceId,
+      tagIds: params.stickerIds,
+    });
+  };
+
+  return {
+    getStickerList,
+    addSticker,
+    updateSticker,
+    deleteSticker,
+    updateResourceStickers,
+  };
 };

--- a/src/services/Tag/TagServices.impl.ts
+++ b/src/services/Tag/TagServices.impl.ts
@@ -2,9 +2,8 @@ import type { ApiResponse } from '@/types/api';
 import Axios from '@/utils/Axios';
 import { normalizeTagGroupId } from '@/utils/normalizeTagGroupId';
 import { checkResponse } from '@/utils/response';
-import { ResourceServicesImpl } from '@/services/Resource/ResourceServices.impl';
+import type { IResourceService } from '@/services/Resource/index.type';
 import { RESOURCE_SORT_BY, RESOURCE_SORT_DIR } from '@/services/Resource/index.type';
-import { useTrashTagStore } from '@/store';
 import { registerServiceCacheCleaner } from '@/services/cacheRegistry';
 import type { TagListByTagResponse } from '@/types/tag';
 import type {
@@ -18,12 +17,9 @@ import type {
   ITagService,
 } from './index.type';
 
-/** 模块级缓存，按 groupId 存储已拉取的标签树；写操作后通过 clearTagTreeCache 清除 */
-const tagTreeCache = new Map<string, TagTreeNode[]>();
-/** 扁平索引：cacheKey → (tagId → TagTreeNode)，与 tagTreeCache 同步维护 */
-const tagFlatCache = new Map<string, Map<string, TagTreeNode>>();
 const CACHE_KEY_DEFAULT = '__default__';
-const HIDDEN_TAG_NAME = '.Trash';
+/** 系统保留前缀：以 `.` 开头的 tag（如 `.Trash`）对 Tag 视图不可见 */
+const HIDDEN_TAG_PREFIX = '.';
 
 const buildFlatMap = (roots: TagTreeNode[]): Map<string, TagTreeNode> => {
   const map = new Map<string, TagTreeNode>();
@@ -35,28 +31,10 @@ const buildFlatMap = (roots: TagTreeNode[]): Map<string, TagTreeNode> => {
   return map;
 };
 
-const syncTrashTagIdToStore = (groupId: string | undefined, roots: TagTreeNode[]): void => {
-  const queue = [...roots];
-  while (queue.length > 0) {
-    const node = queue.shift();
-    if (!node) {
-      continue;
-    }
-    if (node.tagName === '.Trash') {
-      useTrashTagStore.getState().setTrashTagId(groupId, node.tagId);
-      return;
-    }
-    if (Array.isArray(node.children) && node.children.length > 0) {
-      queue.push(...node.children);
-    }
-  }
-  useTrashTagStore.getState().setTrashTagId(groupId, undefined);
-};
-
 const filterHiddenTags = (nodes: TagTreeNode[]): TagTreeNode[] => {
   const filtered: TagTreeNode[] = [];
   for (const node of nodes) {
-    if ((node.tagName ?? '').trim() === HIDDEN_TAG_NAME) {
+    if ((node.tagName ?? '').trim().startsWith(HIDDEN_TAG_PREFIX)) {
       continue;
     }
     filtered.push({
@@ -67,104 +45,115 @@ const filterHiddenTags = (nodes: TagTreeNode[]): TagTreeNode[] => {
   return filtered;
 };
 
-const clearTagTreeCache = (groupId?: string): void => {
-  if (groupId !== undefined) {
-    const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
-    tagTreeCache.delete(cacheKey);
-    tagFlatCache.delete(cacheKey);
-  } else {
-    tagTreeCache.clear();
-    tagFlatCache.clear();
-  }
-};
+export interface TagServicesDeps {
+  resourceService: IResourceService;
+}
 
-registerServiceCacheCleaner(() => clearTagTreeCache());
+export const createTagServices = (deps: TagServicesDeps): ITagService => {
+  const { resourceService } = deps;
 
-const getTagTree = async (groupId?: string): Promise<TagTreeNode[]> => {
-  const normalizedGroupId = normalizeTagGroupId(groupId);
+  /** 按 groupId 存储已拉取的标签树；写操作后通过 clearTagTreeCache 清除 */
+  const tagTreeCache = new Map<string, TagTreeNode[]>();
+  /** 扁平索引：cacheKey → (tagId → TagTreeNode)，与 tagTreeCache 同步维护 */
+  const tagFlatCache = new Map<string, Map<string, TagTreeNode>>();
 
-  const cacheKey = normalizedGroupId ?? CACHE_KEY_DEFAULT;
-  const cached = tagTreeCache.get(cacheKey);
-  if (cached) {
-    syncTrashTagIdToStore(normalizedGroupId, cached);
-    return cached;
-  }
-
-  const params = normalizedGroupId ? { groupId: normalizedGroupId } : undefined;
-  const res = (await Axios.get('/resource/tag/getTagTree', { params })) as ApiResponse<
-    TagTreeResponse[]
-  >;
-  checkResponse(res);
-  // 过滤掉 tagName，分割folder和tag
-  const rawRoots: TagTreeNode[] = (res.data ?? []).filter(
-    (item) => !(item.tagName && item.tagName.startsWith('/'))
-  );
-  const roots: TagTreeNode[] = filterHiddenTags(rawRoots);
-  tagTreeCache.set(cacheKey, roots);
-  tagFlatCache.set(cacheKey, buildFlatMap(roots));
-  syncTrashTagIdToStore(normalizedGroupId, rawRoots);
-  return roots;
-};
-
-const getTagById = (tagId: string, groupId?: string): TagTreeNode | undefined => {
-  const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
-  return tagFlatCache.get(cacheKey)?.get(tagId);
-};
-
-const updateTag = async (params: TagUpdateRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/changeTag', params)) as ApiResponse;
-  checkResponse(res);
-  clearTagTreeCache(params.groupId);
-};
-
-const addTag = async (params: TagCreateRequest): Promise<string> => {
-  const res = (await Axios.post('/resource/tag/addTag', params)) as ApiResponse<string>;
-  checkResponse(res);
-  clearTagTreeCache(params.groupId);
-  return res.data ?? '';
-};
-
-const deleteTag = async (params: TagDeleteRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/removeTag', params)) as ApiResponse;
-  checkResponse(res);
-  clearTagTreeCache(params.groupId);
-};
-
-const getResByTag = async (params: GetResByTagRequest): Promise<TagListByTagResponse> => {
-  const targetTag = params.tag;
-  await getTagTree(targetTag.groupId);
-  const tag = getTagById(targetTag.tagId, targetTag.groupId);
-  const tags = tag?.children ?? [];
-  const filePage = params.filePage ?? 1;
-  const filePageSize = params.filePageSize ?? 20;
-  const listParams = {
-    page: filePage,
-    size: filePageSize,
-    sortBy: RESOURCE_SORT_BY.UPDATE_TIME,
-    sortDir: RESOURCE_SORT_DIR.DESC,
-    tagIds: [targetTag.tagId],
-    tagQueryLogicMode: 'AND' as const,
+  const clearTagTreeCache = (groupId?: string): void => {
+    if (groupId !== undefined) {
+      const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
+      tagTreeCache.delete(cacheKey);
+      tagFlatCache.delete(cacheKey);
+    } else {
+      tagTreeCache.clear();
+      tagFlatCache.clear();
+    }
   };
-  const normalizedGroupId = normalizeTagGroupId(targetTag.groupId);
-  const res = normalizedGroupId
-    ? await ResourceServicesImpl.getGroupResources({ ...listParams, groupId: normalizedGroupId })
-    : await ResourceServicesImpl.getUserResources(listParams);
 
-  return { tags, files: res.list, totalFiles: res.total };
-};
+  registerServiceCacheCleaner(() => clearTagTreeCache());
 
-const moveTag = async (params: TagMoveRequest): Promise<void> => {
-  const res = (await Axios.post('/resource/tag/moveTag', params)) as ApiResponse;
-  checkResponse(res);
-  clearTagTreeCache(params.groupId);
-};
+  const getTagTree = async (groupId?: string): Promise<TagTreeNode[]> => {
+    const normalizedGroupId = normalizeTagGroupId(groupId);
 
-export const TagServicesImpl: ITagService = {
-  getTagTree,
-  getTagById,
-  getResByTag,
-  updateTag,
-  addTag,
-  deleteTag,
-  moveTag,
+    const cacheKey = normalizedGroupId ?? CACHE_KEY_DEFAULT;
+    const cached = tagTreeCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const params = normalizedGroupId ? { groupId: normalizedGroupId } : undefined;
+    const res = (await Axios.get('/resource/tag/getTagTree', { params })) as ApiResponse<
+      TagTreeResponse[]
+    >;
+    checkResponse(res);
+    // 剥离路径型（folder）与系统保留前缀（`.` 开头）
+    const nonFolderRoots: TagTreeNode[] = (res.data ?? []).filter(
+      (item) => !(item.tagName && item.tagName.startsWith('/'))
+    );
+    const roots: TagTreeNode[] = filterHiddenTags(nonFolderRoots);
+    tagTreeCache.set(cacheKey, roots);
+    tagFlatCache.set(cacheKey, buildFlatMap(roots));
+    return roots;
+  };
+
+  const getTagById = (tagId: string, groupId?: string): TagTreeNode | undefined => {
+    const cacheKey = normalizeTagGroupId(groupId) ?? CACHE_KEY_DEFAULT;
+    return tagFlatCache.get(cacheKey)?.get(tagId);
+  };
+
+  const updateTag = async (params: TagUpdateRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/changeTag', params)) as ApiResponse;
+    checkResponse(res);
+    clearTagTreeCache(params.groupId);
+  };
+
+  const addTag = async (params: TagCreateRequest): Promise<string> => {
+    const res = (await Axios.post('/resource/tag/addTag', params)) as ApiResponse<string>;
+    checkResponse(res);
+    clearTagTreeCache(params.groupId);
+    return res.data ?? '';
+  };
+
+  const deleteTag = async (params: TagDeleteRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/removeTag', params)) as ApiResponse;
+    checkResponse(res);
+    clearTagTreeCache(params.groupId);
+  };
+
+  const getResByTag = async (params: GetResByTagRequest): Promise<TagListByTagResponse> => {
+    const targetTag = params.tag;
+    await getTagTree(targetTag.groupId);
+    const tag = getTagById(targetTag.tagId, targetTag.groupId);
+    const tags = tag?.children ?? [];
+    const filePage = params.filePage ?? 1;
+    const filePageSize = params.filePageSize ?? 20;
+    const listParams = {
+      page: filePage,
+      size: filePageSize,
+      sortBy: RESOURCE_SORT_BY.UPDATE_TIME,
+      sortDir: RESOURCE_SORT_DIR.DESC,
+      tagIds: [targetTag.tagId],
+      tagQueryLogicMode: 'AND' as const,
+    };
+    const normalizedGroupId = normalizeTagGroupId(targetTag.groupId);
+    const res = normalizedGroupId
+      ? await resourceService.getGroupResources({ ...listParams, groupId: normalizedGroupId })
+      : await resourceService.getUserResources(listParams);
+
+    return { tags, files: res.list, totalFiles: res.total };
+  };
+
+  const moveTag = async (params: TagMoveRequest): Promise<void> => {
+    const res = (await Axios.post('/resource/tag/moveTag', params)) as ApiResponse;
+    checkResponse(res);
+    clearTagTreeCache(params.groupId);
+  };
+
+  return {
+    getTagTree,
+    getTagById,
+    getResByTag,
+    updateTag,
+    addTag,
+    deleteTag,
+    moveTag,
+  };
 };

--- a/src/services/User/UserServices.impl.ts
+++ b/src/services/User/UserServices.impl.ts
@@ -28,70 +28,12 @@ const toUserSafe = (data: GetUserInfoResponse): CachedUserSafe => {
   };
 };
 
-/** 模块级缓存，仅存非敏感展示字段，退出登录时通过 clearUserCache 清理 */
-let cachedUserInfo: CachedUserSafe | null = null;
-
 /** 全量拉取，为 Account 等页服务，不缓存 */
 const getFullUserInfo = async (): Promise<GetUserInfoResponse> => {
   const res = (await Axios.get('/user/getUserInfo')) as ApiResponse<GetUserInfoResponse>;
   checkResponse(res);
   return res.data;
 };
-
-/** 展示用精简信息，带缓存；无缓存或 forceRefresh 时走 getFullUserInfo 再落缓存 */
-const getUserInfo = async (options?: { forceRefresh?: boolean }): Promise<User> => {
-  const forceRefresh = options?.forceRefresh ?? false;
-  if (!forceRefresh && cachedUserInfo) {
-    return cachedUserInfo;
-  }
-  const data = await getFullUserInfo();
-  cachedUserInfo = toUserSafe(data);
-  return cachedUserInfo;
-};
-
-/** 更新用户信息：按实际传入字段分别 PUT，避免「只改头像」时带空 body 误伤资料表 */
-const updateUserInfo = async (params: UpdateUserInfoRequest): Promise<void> => {
-  const userInfoPayload: Record<string, string | undefined> = {};
-  if (params.nickname !== undefined) userInfoPayload.nickname = params.nickname;
-  if (params.realName !== undefined) userInfoPayload.realName = params.realName;
-  if (params.avatar !== undefined) userInfoPayload.avatar = params.avatar;
-
-  const userProfilePayload: Record<string, string | number | null | undefined> = {};
-  if (params.sex !== undefined) userProfilePayload.sex = params.sex;
-  if (params.university !== undefined) userProfilePayload.university = params.university;
-  if (params.college !== undefined) userProfilePayload.college = params.college;
-  if (params.major !== undefined) userProfilePayload.major = params.major;
-  if (params.className !== undefined) userProfilePayload.className = params.className;
-  if (params.enrollmentYear !== undefined)
-    userProfilePayload.enrollmentYear = params.enrollmentYear;
-  if (params.degreeLevel !== undefined) userProfilePayload.degreeLevel = params.degreeLevel;
-  if (params.academicTitle !== undefined) userProfilePayload.academicTitle = params.academicTitle;
-
-  const tasks: Promise<ApiResponse<unknown>>[] = [];
-  if (Object.keys(userInfoPayload).length > 0) {
-    tasks.push(Axios.put('/user/changeUserInfo', userInfoPayload) as Promise<ApiResponse<unknown>>);
-  }
-  if (Object.keys(userProfilePayload).length > 0) {
-    tasks.push(
-      Axios.put('/user/changeUserProfile', userProfilePayload) as Promise<ApiResponse<unknown>>
-    );
-  }
-  if (tasks.length === 0) {
-    return;
-  }
-  const results = await Promise.all(tasks);
-  results.forEach((res) => {
-    checkResponse(res);
-  });
-
-  cachedUserInfo = null;
-};
-
-const clearUserCache = (): void => {
-  cachedUserInfo = null;
-};
-
-registerServiceCacheCleaner(clearUserCache);
 
 const sendEmailVerify = async (params: SendEmailVerifyRequest): Promise<void> => {
   const res = (await Axios.post('/user/verify/initiateEmailVerify', null, {
@@ -141,13 +83,75 @@ const confirmEmailVerify = async (params: ConfirmEmailVerifyRequest): Promise<vo
   checkResponse(res);
 };
 
-export const UserServicesImpl: IUserService = {
-  getFullUserInfo,
-  getUserInfo,
-  updateUserInfo,
-  sendEmailVerify,
-  initiateUISVerify,
-  checkFudanUISVerify,
-  confirmEmailVerify,
-  clearUserCache,
+export const createUserServices = (): IUserService => {
+  /** 闭包级缓存，仅存非敏感展示字段，退出登录时通过 clearUserCache 清理 */
+  let cachedUserInfo: CachedUserSafe | null = null;
+
+  const clearUserCache = (): void => {
+    cachedUserInfo = null;
+  };
+
+  registerServiceCacheCleaner(clearUserCache);
+
+  /** 展示用精简信息，带缓存；无缓存或 forceRefresh 时走 getFullUserInfo 再落缓存 */
+  const getUserInfo = async (options?: { forceRefresh?: boolean }): Promise<User> => {
+    const forceRefresh = options?.forceRefresh ?? false;
+    if (!forceRefresh && cachedUserInfo) {
+      return cachedUserInfo;
+    }
+    const data = await getFullUserInfo();
+    cachedUserInfo = toUserSafe(data);
+    return cachedUserInfo;
+  };
+
+  /** 更新用户信息：按实际传入字段分别 PUT，避免「只改头像」时带空 body 误伤资料表 */
+  const updateUserInfo = async (params: UpdateUserInfoRequest): Promise<void> => {
+    const userInfoPayload: Record<string, string | undefined> = {};
+    if (params.nickname !== undefined) userInfoPayload.nickname = params.nickname;
+    if (params.realName !== undefined) userInfoPayload.realName = params.realName;
+    if (params.avatar !== undefined) userInfoPayload.avatar = params.avatar;
+
+    const userProfilePayload: Record<string, string | number | null | undefined> = {};
+    if (params.sex !== undefined) userProfilePayload.sex = params.sex;
+    if (params.university !== undefined) userProfilePayload.university = params.university;
+    if (params.college !== undefined) userProfilePayload.college = params.college;
+    if (params.major !== undefined) userProfilePayload.major = params.major;
+    if (params.className !== undefined) userProfilePayload.className = params.className;
+    if (params.enrollmentYear !== undefined)
+      userProfilePayload.enrollmentYear = params.enrollmentYear;
+    if (params.degreeLevel !== undefined) userProfilePayload.degreeLevel = params.degreeLevel;
+    if (params.academicTitle !== undefined) userProfilePayload.academicTitle = params.academicTitle;
+
+    const tasks: Promise<ApiResponse<unknown>>[] = [];
+    if (Object.keys(userInfoPayload).length > 0) {
+      tasks.push(
+        Axios.put('/user/changeUserInfo', userInfoPayload) as Promise<ApiResponse<unknown>>
+      );
+    }
+    if (Object.keys(userProfilePayload).length > 0) {
+      tasks.push(
+        Axios.put('/user/changeUserProfile', userProfilePayload) as Promise<ApiResponse<unknown>>
+      );
+    }
+    if (tasks.length === 0) {
+      return;
+    }
+    const results = await Promise.all(tasks);
+    results.forEach((res) => {
+      checkResponse(res);
+    });
+
+    cachedUserInfo = null;
+  };
+
+  return {
+    getFullUserInfo,
+    getUserInfo,
+    updateUserInfo,
+    sendEmailVerify,
+    initiateUISVerify,
+    checkFudanUISVerify,
+    confirmEmailVerify,
+    clearUserCache,
+  };
 };

--- a/src/services/User/index.ts
+++ b/src/services/User/index.ts
@@ -1,4 +1,3 @@
-export { UserServicesImpl } from './UserServices.impl';
 export type { IUserService } from './index.type';
 export type {
   ConfirmEmailVerifyRequest,

--- a/src/services/Wallet/WalletServices.impl.ts
+++ b/src/services/Wallet/WalletServices.impl.ts
@@ -201,10 +201,10 @@ const transferTokenBetweenGroupAndUser = async (
   checkResponse(res);
 };
 
-export const WalletServicesImpl: IWalletService = {
+export const createWalletServices = (): IWalletService => ({
   getUserWalletInfo,
   redeemVoucher,
   listTransactions,
   listMergedTransactions,
   transferTokenBetweenGroupAndUser,
-};
+});

--- a/src/utils/validateReservedName.ts
+++ b/src/utils/validateReservedName.ts
@@ -1,0 +1,33 @@
+/**
+ * tag / folder / sticker 等命名场景的通用前缀保留校验。
+ *
+ * 背景：
+ * - `/` 前缀代表路径型（folder）节点，由 Folder 域统一托管；
+ * - `.` 前缀为系统保留命名空间（如 `.Trash`），对业务视图不可见。
+ *
+ * Service 读取侧会按上述前缀过滤结果；写入侧若不拦截，会产生"创建成功但立刻消失"的脏数据，
+ * 因此在 UI 输入层统一拦截。
+ */
+
+const RESERVED_PREFIXES = ['.', '/'] as const;
+
+/** 统一提示文案（系统保留字符） */
+export const RESERVED_NAME_HINT = '`.` 和 `/` 为系统保留字符，名称不能以此开头';
+
+export interface ReservedNameValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * 校验名称是否触达系统保留前缀。
+ * @param trimmed 已 trim 过的候选名称；调用方须先保证非空。
+ */
+export const validateReservedName = (trimmed: string): ReservedNameValidationResult => {
+  for (const prefix of RESERVED_PREFIXES) {
+    if (trimmed.startsWith(prefix)) {
+      return { valid: false, reason: RESERVED_NAME_HINT };
+    }
+  }
+  return { valid: true };
+};


### PR DESCRIPTION
- 全部 service 实现迁移为工厂方法，registry 显式分层装配.
- .Trash 语义收敛到 Folder 域：由 Folder 维护 trash store，Folder 不再依赖 TagService.
- 新增 utils/validateReservedName拦截 . 或 / 开头的命名，提示"`.` 和 `/` 为系统保留字符"