### PR TITLE
新增管理端用户表格与 Admin 服务

### DIFF
--- a/src/components/Admin/UserTable/index.tsx
+++ b/src/components/Admin/UserTable/index.tsx
@@ -1,0 +1,128 @@
+import type { AdminUser } from '@/domains/Admin';
+import { IDENTITY, USER_STATUS } from '@/domains/User/enum';
+import { Avatar, Table, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { useMemo } from 'react';
+import type { AdminUserTableProps } from './index.type';
+import styles from './style.module.less';
+
+const EMPTY_TEXT = '-';
+
+const formatOptionalText = (value?: string): string => {
+  return value && value.trim() ? value : EMPTY_TEXT;
+};
+
+const getDisplayName = (user: AdminUser): string => {
+  return user.realName || user.nickname || user.username || EMPTY_TEXT;
+};
+
+function AdminUserTable({
+  users,
+  loading = false,
+  total,
+  currentPage,
+  pageSize,
+  onPageChange,
+  onRowClick,
+}: AdminUserTableProps) {
+  const columns = useMemo<ColumnsType<AdminUser>>(
+    () => [
+      {
+        title: '用户',
+        dataIndex: 'realName',
+        key: 'user',
+        width: 220,
+        ellipsis: true,
+        render: (_value, record) => (
+          <div className={styles.userCell}>
+            <Avatar size={32} src={record.avatar}>
+              {getDisplayName(record).slice(0, 1)}
+            </Avatar>
+            <div className={styles.userMeta}>
+              <div className={styles.primaryText}>{getDisplayName(record)}</div>
+              <div className={styles.secondaryText}>{formatOptionalText(record.nickname)}</div>
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: '用户名',
+        dataIndex: 'username',
+        key: 'username',
+        width: 160,
+        ellipsis: true,
+        render: (value?: string) => formatOptionalText(value),
+      },
+      {
+        title: '学工号',
+        dataIndex: 'campusNo',
+        key: 'campusNo',
+        width: 140,
+        ellipsis: true,
+        render: (value?: string) => formatOptionalText(value),
+      },
+      {
+        title: '身份',
+        dataIndex: 'identityType',
+        key: 'identityType',
+        width: 96,
+        render: (value: number) => <Tag>{IDENTITY.getLabel(value) || EMPTY_TEXT}</Tag>,
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        key: 'status',
+        width: 96,
+        render: (value: number) => {
+          const color = value === 1 ? 'success' : value === -2 ? 'error' : 'warning';
+          return <Tag color={color}>{USER_STATUS.getLabel(value) || EMPTY_TEXT}</Tag>;
+        },
+      },
+      {
+        title: '邮箱',
+        dataIndex: 'email',
+        key: 'email',
+        width: 220,
+        ellipsis: true,
+        render: (value?: string) => formatOptionalText(value),
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createTime',
+        key: 'createTime',
+        width: 180,
+        ellipsis: true,
+        render: (value?: string) => formatOptionalText(value),
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className={styles.tableWrapper}>
+      <Table<AdminUser>
+        rowKey="id"
+        size="small"
+        loading={loading}
+        columns={columns}
+        dataSource={users}
+        scroll={{ x: 1112 }}
+        pagination={{
+          total,
+          current: currentPage,
+          pageSize,
+          showSizeChanger: true,
+          showTotal: (value) => `共 ${value} 条`,
+          onChange: onPageChange,
+          onShowSizeChange: onPageChange,
+        }}
+        onRow={(record) => ({
+          className: styles.clickableRow,
+          onClick: () => onRowClick(record.id),
+        })}
+      />
+    </div>
+  );
+}
+
+export default AdminUserTable;

--- a/src/components/Admin/UserTable/index.type.ts
+++ b/src/components/Admin/UserTable/index.type.ts
@@ -1,0 +1,11 @@
+import type { AdminUser } from '@/domains/Admin';
+
+export interface AdminUserTableProps {
+  users: AdminUser[];
+  loading?: boolean;
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number, pageSize: number) => void;
+  onRowClick: (userId: string) => void;
+}

--- a/src/components/Admin/UserTable/style.module.less
+++ b/src/components/Admin/UserTable/style.module.less
@@ -1,0 +1,38 @@
+.tableWrapper {
+  min-width: 0;
+}
+
+.userCell {
+  display: flex;
+  align-items: center;
+  gap: var(--ant-margin-sm);
+  min-width: 0;
+}
+
+.userMeta {
+  min-width: 0;
+}
+
+.primaryText {
+  overflow: hidden;
+  color: var(--ant-color-text);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.secondaryText {
+  overflow: hidden;
+  color: var(--ant-color-text-tertiary);
+  font-size: var(--ant-font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emptyText {
+  color: var(--ant-color-text-quaternary);
+}
+
+.clickableRow {
+  cursor: pointer;
+}

--- a/src/domains/Admin/apis/AdminUserApi.ts
+++ b/src/domains/Admin/apis/AdminUserApi.ts
@@ -1,0 +1,40 @@
+import { apiGet, apiPost, apiPut } from '@/apis/request';
+import type {
+  ChangeAdminUserInfoApiRequest,
+  ChangeAdminUserProfileApiRequest,
+  FetchAdminUserListApiRequest,
+  FetchAdminUserListApiResponse,
+  GetAdminUserInfoApiRequest,
+  GetAdminUserInfoApiResponse,
+  ResetAdminUserPasswordApiRequest,
+} from './AdminUserApi.type';
+
+/** Admin User API: /admin/user/* */
+
+function getUserList(req: FetchAdminUserListApiRequest): Promise<FetchAdminUserListApiResponse> {
+  return apiGet('/admin/user/getUserList', { params: req });
+}
+
+function getUserInfo(req: GetAdminUserInfoApiRequest): Promise<GetAdminUserInfoApiResponse> {
+  return apiGet('/admin/user/getUserInfo', { params: req });
+}
+
+function changeUserInfo(req: ChangeAdminUserInfoApiRequest): Promise<void> {
+  return apiPut('/admin/user/changeUserInfo', req);
+}
+
+function changeUserProfile(req: ChangeAdminUserProfileApiRequest): Promise<void> {
+  return apiPut('/admin/user/changeUserProfile', req);
+}
+
+function resetPassword(req: ResetAdminUserPasswordApiRequest): Promise<void> {
+  return apiPost('/admin/user/resetPassword', null, { params: req });
+}
+
+export const AdminUserApi = {
+  getUserList,
+  getUserInfo,
+  changeUserInfo,
+  changeUserProfile,
+  resetPassword,
+};

--- a/src/domains/Admin/apis/AdminUserApi.type.ts
+++ b/src/domains/Admin/apis/AdminUserApi.type.ts
@@ -1,0 +1,73 @@
+import type { UserVerificationMode } from '@/domains/User/enum';
+
+export interface AdminUserApiModel {
+  id?: string | number | null;
+  userId?: string | number | null;
+  username?: string | null;
+  nickname?: string | null;
+  realName?: string | null;
+  avatar?: string | null;
+  identityType?: number | null;
+  campusNo?: string | null;
+  email?: string | null;
+  mobile?: string | null;
+  verificationMode?: UserVerificationMode | null;
+  status?: number | null;
+  createTime?: string | null;
+  updateTime?: string | null;
+}
+
+export interface FetchAdminUserListApiRequest {
+  page: number;
+  size: number;
+  keyword: string;
+  status: number;
+  identityType: number;
+}
+
+export interface PageR<T> {
+  list: T[];
+  total: number;
+  page: number;
+  size: number;
+  totalPage: number;
+}
+
+export type FetchAdminUserListApiResponse = PageR<AdminUserApiModel>;
+
+export interface GetAdminUserInfoApiRequest {
+  userId: string;
+}
+
+export interface GetAdminUserInfoApiResponse {
+  userInfo: AdminUserApiModel;
+  userProfile?: Record<string, unknown> | null;
+  readonlyFields?: string[] | null;
+}
+
+export interface ChangeAdminUserInfoApiRequest {
+  userId: string;
+  nickname?: string;
+  realName?: string;
+  avatar?: string;
+  email?: string | null;
+  mobile?: string | null;
+  status?: number;
+  identityType?: number;
+}
+
+export interface ChangeAdminUserProfileApiRequest {
+  userId: string;
+  sex?: number;
+  university?: string | null;
+  college?: string;
+  major?: string;
+  className?: string;
+  enrollmentYear?: string;
+  degreeLevel?: number;
+  academicTitle?: string;
+}
+
+export interface ResetAdminUserPasswordApiRequest {
+  userId: string;
+}

--- a/src/domains/Admin/entity/adminUser.ts
+++ b/src/domains/Admin/entity/adminUser.ts
@@ -1,0 +1,17 @@
+import type { UserVerificationMode } from '@/domains/User/enum';
+
+export interface AdminUser {
+  id: string;
+  username: string;
+  nickname?: string;
+  realName?: string;
+  avatar?: string;
+  identityType: number;
+  campusNo?: string;
+  email?: string;
+  mobile?: string;
+  verificationMode?: UserVerificationMode | null;
+  status: number;
+  createTime?: string;
+  updateTime?: string;
+}

--- a/src/domains/Admin/index.ts
+++ b/src/domains/Admin/index.ts
@@ -1,0 +1,11 @@
+export type { AdminUser } from './entity/adminUser';
+export type {
+  ChangeAdminUserInfoRequest,
+  ChangeAdminUserProfileRequest,
+  FetchAdminUserListRequest,
+  FetchAdminUserListResponse,
+  GetAdminUserInfoRequest,
+  GetAdminUserInfoResponse,
+  IAdminService,
+  ResetAdminUserPasswordRequest,
+} from './service/index.type';

--- a/src/domains/Admin/mapper/AdminUserServices.map.ts
+++ b/src/domains/Admin/mapper/AdminUserServices.map.ts
@@ -1,0 +1,46 @@
+import type { AdminUser } from '@/domains/Admin';
+import { normalizeId } from '@/utils/normalize/normalizeId';
+import type {
+  AdminUserApiModel,
+  FetchAdminUserListApiRequest,
+  FetchAdminUserListApiResponse,
+} from '../apis/AdminUserApi.type';
+import type { FetchAdminUserListRequest, FetchAdminUserListResponse } from '../service/index.type';
+
+export const mapAdminUserApiModelToEntity = (raw: AdminUserApiModel): AdminUser => {
+  return {
+    id: normalizeId(raw.id ?? raw.userId),
+    username: raw.username ?? '',
+    nickname: raw.nickname ?? undefined,
+    realName: raw.realName ?? undefined,
+    avatar: raw.avatar ?? undefined,
+    identityType: raw.identityType ?? 0,
+    campusNo: raw.campusNo ?? undefined,
+    email: raw.email ?? undefined,
+    mobile: raw.mobile ?? undefined,
+    verificationMode: raw.verificationMode ?? null,
+    status: raw.status ?? 0,
+    createTime: raw.createTime ?? undefined,
+    updateTime: raw.updateTime ?? undefined,
+  };
+};
+
+export const mapFetchAdminUserListRequestToApi = (
+  params: FetchAdminUserListRequest
+): FetchAdminUserListApiRequest => ({
+  page: params.page,
+  size: params.size,
+  keyword: params.keyword,
+  status: params.status,
+  identityType: params.identityType,
+});
+
+export const mapFetchAdminUserListResponse = (
+  data: FetchAdminUserListApiResponse
+): FetchAdminUserListResponse => ({
+  users: data.list.map(mapAdminUserApiModelToEntity),
+  total: data.total,
+  page: data.page,
+  size: data.size,
+  totalPage: data.totalPage,
+});

--- a/src/domains/Admin/mock/AdminServices.mock.ts
+++ b/src/domains/Admin/mock/AdminServices.mock.ts
@@ -1,0 +1,65 @@
+import type { AdminUserApiModel } from '../apis/AdminUserApi.type';
+import { mapAdminUserApiModelToEntity } from '../mapper/AdminUserServices.map';
+import type {
+  ChangeAdminUserInfoRequest,
+  ChangeAdminUserProfileRequest,
+  FetchAdminUserListRequest,
+  FetchAdminUserListResponse,
+  GetAdminUserInfoRequest,
+  GetAdminUserInfoResponse,
+  IAdminService,
+  ResetAdminUserPasswordRequest,
+} from '../service/index.type';
+import mockdata from './mockdata.json';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const rawUsers = mockdata.users as AdminUserApiModel[];
+
+const fetchUserList = async (
+  params: FetchAdminUserListRequest
+): Promise<FetchAdminUserListResponse> => {
+  await delay(200);
+  const users = rawUsers.map(mapAdminUserApiModelToEntity);
+  const start = (params.page - 1) * params.size;
+  const list = users.slice(start, start + params.size);
+  return {
+    users: list,
+    total: users.length,
+    page: params.page,
+    size: params.size,
+    totalPage: Math.ceil(users.length / params.size),
+  };
+};
+
+const getUserInfo = async (params: GetAdminUserInfoRequest): Promise<GetAdminUserInfoResponse> => {
+  await delay(200);
+  const user =
+    rawUsers.map(mapAdminUserApiModelToEntity).find((item) => item.id === params.userId) ??
+    mapAdminUserApiModelToEntity(rawUsers[0]);
+  return {
+    user,
+    userProfile: null,
+    readonlyFields: null,
+  };
+};
+
+const changeUserInfo = async (_params: ChangeAdminUserInfoRequest): Promise<void> => {
+  await delay(200);
+};
+
+const changeUserProfile = async (_params: ChangeAdminUserProfileRequest): Promise<void> => {
+  await delay(200);
+};
+
+const resetPassword = async (_params: ResetAdminUserPasswordRequest): Promise<void> => {
+  await delay(200);
+};
+
+export const AdminServicesMock: IAdminService = {
+  fetchUserList,
+  getUserInfo,
+  changeUserInfo,
+  changeUserProfile,
+  resetPassword,
+};

--- a/src/domains/Admin/mock/mockdata.json
+++ b/src/domains/Admin/mock/mockdata.json
@@ -1,0 +1,34 @@
+{
+  "users": [
+    {
+      "id": "9007199254740993",
+      "username": "admin.student",
+      "nickname": "青梧",
+      "realName": "陈一",
+      "avatar": "",
+      "identityType": 1,
+      "campusNo": "22300000001",
+      "email": "student@example.com",
+      "mobile": "13800000001",
+      "verificationMode": "EDU_EMAIL",
+      "status": 1,
+      "createTime": "2026-05-01 10:00:00",
+      "updateTime": "2026-05-10 12:00:00"
+    },
+    {
+      "userId": "9007199254740994",
+      "username": "admin.teacher",
+      "nickname": "明远",
+      "realName": "李二",
+      "avatar": "",
+      "identityType": 2,
+      "campusNo": "T20260001",
+      "email": "teacher@example.com",
+      "mobile": "13800000002",
+      "verificationMode": "FDU_UIS_SYS",
+      "status": -1,
+      "createTime": "2026-05-02 11:00:00",
+      "updateTime": "2026-05-11 13:00:00"
+    }
+  ]
+}

--- a/src/domains/Admin/service/AdminServices.impl.ts
+++ b/src/domains/Admin/service/AdminServices.impl.ts
@@ -1,0 +1,52 @@
+import { AdminUserApi } from '../apis/AdminUserApi';
+import {
+  mapAdminUserApiModelToEntity,
+  mapFetchAdminUserListRequestToApi,
+  mapFetchAdminUserListResponse,
+} from '../mapper/AdminUserServices.map';
+import type {
+  ChangeAdminUserInfoRequest,
+  ChangeAdminUserProfileRequest,
+  FetchAdminUserListRequest,
+  FetchAdminUserListResponse,
+  GetAdminUserInfoRequest,
+  GetAdminUserInfoResponse,
+  IAdminService,
+  ResetAdminUserPasswordRequest,
+} from './index.type';
+
+const fetchUserList = async (
+  params: FetchAdminUserListRequest
+): Promise<FetchAdminUserListResponse> => {
+  const data = await AdminUserApi.getUserList(mapFetchAdminUserListRequestToApi(params));
+  return mapFetchAdminUserListResponse(data);
+};
+
+const getUserInfo = async (params: GetAdminUserInfoRequest): Promise<GetAdminUserInfoResponse> => {
+  const data = await AdminUserApi.getUserInfo(params);
+  return {
+    user: mapAdminUserApiModelToEntity(data.userInfo),
+    userProfile: data.userProfile ?? null,
+    readonlyFields: data.readonlyFields ?? null,
+  };
+};
+
+const changeUserInfo = async (params: ChangeAdminUserInfoRequest): Promise<void> => {
+  await AdminUserApi.changeUserInfo(params);
+};
+
+const changeUserProfile = async (params: ChangeAdminUserProfileRequest): Promise<void> => {
+  await AdminUserApi.changeUserProfile(params);
+};
+
+const resetPassword = async (params: ResetAdminUserPasswordRequest): Promise<void> => {
+  await AdminUserApi.resetPassword(params);
+};
+
+export const createAdminServices = (): IAdminService => ({
+  fetchUserList,
+  getUserInfo,
+  changeUserInfo,
+  changeUserProfile,
+  resetPassword,
+});

--- a/src/domains/Admin/service/index.type.ts
+++ b/src/domains/Admin/service/index.type.ts
@@ -1,0 +1,62 @@
+import type { AdminUser } from '@/domains/Admin';
+
+export interface IAdminService {
+  fetchUserList(params: FetchAdminUserListRequest): Promise<FetchAdminUserListResponse>;
+  getUserInfo(params: GetAdminUserInfoRequest): Promise<GetAdminUserInfoResponse>;
+  changeUserInfo(params: ChangeAdminUserInfoRequest): Promise<void>;
+  changeUserProfile(params: ChangeAdminUserProfileRequest): Promise<void>;
+  resetPassword(params: ResetAdminUserPasswordRequest): Promise<void>;
+}
+
+export interface FetchAdminUserListRequest {
+  page: number;
+  size: number;
+  keyword: string;
+  status: number;
+  identityType: number;
+}
+
+export interface FetchAdminUserListResponse {
+  users: AdminUser[];
+  total: number;
+  page: number;
+  size: number;
+  totalPage: number;
+}
+
+export interface GetAdminUserInfoRequest {
+  userId: string;
+}
+
+export interface GetAdminUserInfoResponse {
+  user: AdminUser;
+  userProfile?: Record<string, unknown> | null;
+  readonlyFields?: string[] | null;
+}
+
+export interface ChangeAdminUserInfoRequest {
+  userId: string;
+  nickname?: string;
+  realName?: string;
+  avatar?: string;
+  email?: string | null;
+  mobile?: string | null;
+  status?: number;
+  identityType?: number;
+}
+
+export interface ChangeAdminUserProfileRequest {
+  userId: string;
+  sex?: number;
+  university?: string | null;
+  college?: string;
+  major?: string;
+  className?: string;
+  enrollmentYear?: string;
+  degreeLevel?: number;
+  academicTitle?: string;
+}
+
+export interface ResetAdminUserPasswordRequest {
+  userId: string;
+}

--- a/src/domains/_registry/hooks.ts
+++ b/src/domains/_registry/hooks.ts
@@ -1,5 +1,6 @@
 import { use } from 'react';
 
+import type { IAdminService } from '@/domains/Admin';
 import type { IAuthService } from '@/domains/Auth';
 import type { IChatService } from '@/domains/Chat';
 import type { IDocumentService } from '@/domains/Document';
@@ -26,6 +27,7 @@ function useServicesContext(): ServicesContextValue {
   return ctx;
 }
 
+export const useAdminService = (): IAdminService => useServicesContext().adminService;
 export const useAuthService = (): IAuthService => useServicesContext().authService;
 export const useChatService = (): IChatService => useServicesContext().chatService;
 export const useDocumentService = (): IDocumentService => useServicesContext().documentService;

--- a/src/domains/_registry/index.ts
+++ b/src/domains/_registry/index.ts
@@ -28,6 +28,7 @@
  */
 
 export {
+  useAdminService,
   useAuthService,
   useChatService,
   useDocumentService,

--- a/src/domains/_registry/registry.impl.ts
+++ b/src/domains/_registry/registry.impl.ts
@@ -10,6 +10,7 @@
  * 为避免循环依赖与隐式耦合，service 间不得互相直接 import 实现，必须经此装配。
  * 新增更深层级（Level 2+）时在此文件延展，保持"分层 + 显式注入"。
  */
+import { createAdminServices } from '@/domains/Admin/service/AdminServices.impl';
 import { createAuthServices } from '@/domains/Auth/service/AuthServices.impl';
 import { createChatServices } from '@/domains/Chat/service/ChatServices.impl';
 import { createDocumentServices } from '@/domains/Document/service/DocumentServices.impl';
@@ -27,6 +28,7 @@ import { createWalletServices } from '@/domains/Wallet/service/WalletServices.im
 import type { ServicesContextValue } from './registry.types';
 
 // Level 0：无跨 service 依赖
+const adminService = createAdminServices();
 const authService = createAuthServices();
 const chatService = createChatServices();
 const documentService = createDocumentServices();
@@ -47,6 +49,7 @@ const driveService = createDriveServices({
 });
 
 const servicesValue: ServicesContextValue = {
+  adminService: adminService,
   authService: authService,
   chatService: chatService,
   documentService: documentService,

--- a/src/domains/_registry/registry.mock.ts
+++ b/src/domains/_registry/registry.mock.ts
@@ -1,6 +1,7 @@
 /**
  * Mock 服务注册表：仅绑定 *Services.mock.ts
  */
+import { AdminServicesMock } from '@/domains/Admin/mock/AdminServices.mock';
 import { AuthServicesMock } from '@/domains/Auth/mock/AuthServices.mock';
 import { ChatServicesMock } from '@/domains/Chat/mock/ChatServices.mock';
 import { DocumentServicesMock } from '@/domains/Document/mock/DocumentServices.mock';
@@ -18,6 +19,7 @@ import { WalletServicesMock } from '@/domains/Wallet/mock/WalletServices.mock';
 import type { ServicesContextValue } from './registry.types';
 
 const mockServicesValue: ServicesContextValue = {
+  adminService: AdminServicesMock,
   authService: AuthServicesMock,
   chatService: ChatServicesMock,
   documentService: DocumentServicesMock,

--- a/src/domains/_registry/registry.types.ts
+++ b/src/domains/_registry/registry.types.ts
@@ -1,3 +1,4 @@
+import type { IAdminService } from '@/domains/Admin';
 import type { IAuthService } from '@/domains/Auth';
 import type { IChatService } from '@/domains/Chat';
 import type { IDocumentService } from '@/domains/Document';
@@ -13,6 +14,7 @@ import type { IUserService } from '@/domains/User';
 import type { IWalletService } from '@/domains/Wallet';
 
 export interface ServicesContextValue {
+  adminService: IAdminService;
   authService: IAuthService;
   chatService: IChatService;
   documentService: IDocumentService;

--- a/src/domains/index.ts
+++ b/src/domains/index.ts
@@ -3,6 +3,7 @@
  */
 export {
   ServicesProvider,
+  useAdminService,
   useAuthService,
   useChatService,
   useDocumentService,


### PR DESCRIPTION
## 变更内容
- 新增 Admin domain，封装 /admin/user/* 相关 API、service、mapper 和 mock。
- 注册 useAdminService 到真实与 mock registry。
- 新增 Admin/UserTable 组件，支持用户列表展示、分页和行点击回调。

## 验证
- npm run build
- npm run lint
- pre-push lint 通过