### PR TITLE
feat(EditGroupModal): 编辑小组时展示当前封面预览

### DIFF
--- a/src/components/Group/GroupModals/EditGroupInfoModal/index.tsx
+++ b/src/components/Group/GroupModals/EditGroupInfoModal/index.tsx
@@ -27,6 +27,18 @@ const fileFromCoverField = (fileList?: UploadFile[]): File | undefined => {
   return raw instanceof File ? raw : undefined;
 };
 
+const fileListFromCover = (cover?: string): UploadFile[] =>
+  cover
+    ? [
+        {
+          uid: '-1',
+          name: 'cover',
+          status: 'done',
+          url: cover,
+        },
+      ]
+    : [];
+
 function EditGroupInfoModal({
   open,
   onCancel,
@@ -84,7 +96,7 @@ function EditGroupInfoModal({
 
   const handleOpenChange = (visible: boolean) => {
     if (!visible) return;
-    form.setFieldsValue({ groupName, groupDesc: description });
+    form.setFieldsValue({ groupName, groupDesc: description, cover: fileListFromCover(cover) });
   };
 
   const handleConfirm = async () => {
@@ -130,7 +142,13 @@ function EditGroupInfoModal({
           valuePropName="fileList"
           getValueFromEvent={normalizeUpload}
         >
-          <Upload name="file" beforeUpload={beforeUploadCover} accept="image/*" maxCount={1}>
+          <Upload
+            name="file"
+            beforeUpload={beforeUploadCover}
+            accept="image/*"
+            maxCount={1}
+            listType="picture-card"
+          >
             <Button>
               <IconText icon={<LuUpload />} iconSize={16}>
                 点击上传


### PR DESCRIPTION
## Summary
- 在编辑小组弹窗打开时，将已有 cover 转换为 Upload fileList  (fileListFromCover)
- 使用 picture-card 上传列表展示当前封面缩略图
- 保持未选择新图片时继续提交原 cover 的逻辑

## Test Plan
- pnpm lint
- mock 模式下临时给小组配置 cover，打开编辑弹窗可看到封面缩略图
- 选择新图片后上传区域展示新图片
- 不选择新图片直接保存，原封面不被清空


Closes #61