### PR TITLE
feat(TableDrive): 文件列表 loadMore 行增加加载状态

### DIFF
--- a/src/components/Drive/TableDrive/config/columnConfig.tsx
+++ b/src/components/Drive/TableDrive/config/columnConfig.tsx
@@ -21,6 +21,7 @@ export interface TableDriveColumnConfigOptions {
     loadMoreCell: string;
     optionBtn: string;
   };
+  loadingMoreParentId: string | null;
   actionConfig?: TableDriveActionConfig;
   openDropdownKey: string | null;
   setOpenDropdownKey: (key: string | null) => void;
@@ -61,7 +62,14 @@ function renderRowName(record: DriveRow): string {
 export function getTableDriveColumns(
   options: TableDriveColumnConfigOptions
 ): ColumnsType<DriveRow> {
-  const { styles, actionConfig, openDropdownKey, setOpenDropdownKey, onRowAction } = options;
+  const {
+    styles,
+    loadingMoreParentId,
+    actionConfig,
+    openDropdownKey,
+    setOpenDropdownKey,
+    onRowAction,
+  } = options;
 
   return [
     {
@@ -73,10 +81,13 @@ export function getTableDriveColumns(
       render: (_: unknown, record: DriveRow) => {
         // loadMore 行跨整行渲染（colSpan = 全部列数）
         if (record.type === 'loadMore') {
+          const isLoadingMore = loadingMoreParentId === record.parentId;
           return {
             children: (
-              <button type="button" className={styles.loadMoreCell}>
-                加载更多（已加载 {record.loaded} / 共 {record.total}）
+              <button type="button" className={styles.loadMoreCell} disabled={isLoadingMore}>
+                {isLoadingMore
+                  ? '加载中...'
+                  : `加载更多（已加载 ${record.loaded} / 共 ${record.total}）`}
               </button>
             ),
             props: { colSpan: TOTAL_COLUMNS },

--- a/src/components/Drive/TableDrive/index.tsx
+++ b/src/components/Drive/TableDrive/index.tsx
@@ -29,6 +29,7 @@ function TableDrive({ groupId, rootId, scope, actions }: TableDriveProps) {
     dataSource,
     pathNodes,
     loading,
+    loadingMoreParentId,
     expandedRowKeys,
     enterFolder,
     handleLoadMore,
@@ -126,12 +127,13 @@ function TableDrive({ groupId, rootId, scope, actions }: TableDriveProps) {
           loadMoreCell: styles.loadMoreCell,
           optionBtn: styles.optionBtn,
         },
+        loadingMoreParentId,
         actionConfig: actions,
         onRowAction,
         openDropdownKey,
         setOpenDropdownKey,
       }),
-    [actions, onRowAction, openDropdownKey, setOpenDropdownKey]
+    [actions, loadingMoreParentId, onRowAction, openDropdownKey, setOpenDropdownKey]
   );
 
   const expandIcon = useCallback(

--- a/src/components/Drive/TableDrive/useTableDrive.ts
+++ b/src/components/Drive/TableDrive/useTableDrive.ts
@@ -19,6 +19,7 @@ interface UseTableDriveReturn {
   /** breadcrumb 路径（含目标节点本身） */
   pathNodes: DriveNode[];
   loading: boolean;
+  loadingMoreParentId: string | null;
   expandedRowKeys: string[];
   /** 进入子目录（仅 folder 调用） */
   enterFolder: (nodeId: string) => void;
@@ -42,6 +43,7 @@ export function useTableDrive({ rootId, groupId }: UseTableDriveParams): UseTabl
   const [currentNodeId, setCurrentNodeId] = useState<string>(rootId);
   const [rows, setRows] = useState<DriveRow[]>([]);
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
+  const [loadingMoreParentId, setLoadingMoreParentId] = useState<string | null>(null);
 
   // 切换 currentNodeId / groupId：拉取当前层级 children
   const { loading, refresh } = useRequest(
@@ -78,12 +80,19 @@ export function useTableDrive({ rootId, groupId }: UseTableDriveParams): UseTabl
 
   const handleLoadMore = useCallback(
     async (node: LoadMoreNode) => {
-      const next = await loadMore(node);
-      if (node.parentId === currentNodeId) {
-        setRows(next as DriveRow[]);
+      // 加载期间忽略重复点击
+      if (loadingMoreParentId === node.parentId) return;
+      setLoadingMoreParentId(node.parentId);
+      try {
+        const next = await loadMore(node);
+        if (node.parentId === currentNodeId) {
+          setRows(next as DriveRow[]);
+        }
+      } finally {
+        setLoadingMoreParentId(null);
       }
     },
-    [loadMore, currentNodeId]
+    [loadMore, currentNodeId, loadingMoreParentId]
   );
 
   const handleExpand = useCallback(
@@ -110,6 +119,7 @@ export function useTableDrive({ rootId, groupId }: UseTableDriveParams): UseTabl
     dataSource,
     pathNodes,
     loading,
+    loadingMoreParentId,
     expandedRowKeys,
     enterFolder,
     handleLoadMore,


### PR DESCRIPTION
## Summary
- 为 TableDrive 的 loadMore 行增加加载中状态展示
- 加载期间禁用 loadMore 按钮并忽略重复点击
- 保持现有分页数据结构不变，仅在组件状态中维护 loadingMoreParentId
## Test Plan
- mock 模式下进入“大目录（loadMore 验证）”
- 点击 loadMore 行后可看到“加载中...”
- 加载期间重复点击不会重复触发
- 加载完成后恢复“加载更多（已加载 x / 共 y）”

Close #62