### PR TITLE
重构 HeroUI 主题圆角配置

### DIFF
--- a/src/bootstrap/index.css
+++ b/src/bootstrap/index.css
@@ -5,24 +5,205 @@
 @import '../theme/heroui/wisepen.css' layer(theme);
 
 @theme inline {
+  --font-sans: var(--app-font-family);
+  --font-mono: var(--app-font-mono);
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+
+  --color-surface: var(--surface);
+  --color-surface-foreground: var(--surface-foreground);
+  --color-surface-hover: var(--surface-hover);
+
+  --color-surface-secondary: var(--surface-secondary);
+  --color-surface-secondary-foreground: var(--surface-secondary-foreground);
+
+  --color-surface-tertiary: var(--surface-tertiary);
+  --color-surface-tertiary-foreground: var(--surface-tertiary-foreground);
+
+  --color-overlay: var(--overlay);
+  --color-overlay-foreground: var(--overlay-foreground);
+
+  --color-muted: var(--muted);
+
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+
+  --color-segment: var(--segment);
+  --color-segment-foreground: var(--segment-foreground);
+
+  --color-border: var(--border);
+  --color-separator: var(--separator);
+  --color-focus: var(--focus);
+  --color-link: var(--link);
+
+  --color-default: var(--default);
+  --color-default-foreground: var(--default-foreground);
+
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+
+  --color-danger: var(--danger);
+  --color-danger-foreground: var(--danger-foreground);
+
+  --color-backdrop: var(--backdrop);
+
+  --shadow-surface: var(--surface-shadow);
+  --shadow-overlay: var(--overlay-shadow);
+  --shadow-field: var(--field-shadow);
+
+  --color-field: var(--field-background, var(--default));
+  --color-field-hover: var(--field-hover);
+  --color-field-foreground: var(--field-foreground, var(--foreground));
+  --color-field-placeholder: var(--field-placeholder, var(--muted));
+  --color-field-border: var(--field-border, var(--border));
+  --radius-field: var(--field-radius, calc(var(--radius) * 1.5));
+  --border-width-field: var(--field-border-width, var(--border-width));
+
+  --color-background-secondary: var(--background-secondary);
+  --color-background-tertiary: var(--background-tertiary);
+  --color-background-inverse: var(--background-inverse);
+
+  --color-default-hover: var(--default-hover);
+  --color-accent-hover: var(--accent-hover);
+  --color-success-hover: var(--success-hover);
+  --color-warning-hover: var(--warning-hover);
+  --color-danger-hover: var(--danger-hover);
+
+  --color-field-focus: var(--field-focus);
+  --color-field-border-hover: var(--field-border-hover);
+  --color-field-border-focus: var(--field-border-focus);
+
+  --color-default-soft: var(--default-soft);
+  --color-default-soft-foreground: var(--default-soft-foreground);
+  --color-default-soft-hover: var(--default-soft-hover);
+
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-soft-foreground: var(--accent-soft-foreground);
+  --color-accent-soft-hover: var(--accent-soft-hover);
+
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-soft-foreground: var(--danger-soft-foreground);
+  --color-danger-soft-hover: var(--danger-soft-hover);
+
+  --color-warning-soft: var(--warning-soft);
+  --color-warning-soft-foreground: var(--warning-soft-foreground);
+  --color-warning-soft-hover: var(--warning-soft-hover);
+
+  --color-success-soft: var(--success-soft);
+  --color-success-soft-foreground: var(--success-soft-foreground);
+  --color-success-soft-hover: var(--success-soft-hover);
+
+  --color-separator-secondary: var(--separator-secondary);
+  --color-separator-tertiary: var(--separator-tertiary);
+
+  --color-border-secondary: var(--border-secondary);
+  --color-border-tertiary: var(--border-tertiary);
+
+  --radius-xs: calc(var(--radius) * 0.25);
+  --radius-sm: calc(var(--radius) * 0.5);
+  --radius-md: calc(var(--radius) * 0.75);
+  --radius-lg: calc(var(--radius) * 1);
+  --radius-xl: calc(var(--radius) * 1.5);
+  --radius-2xl: calc(var(--radius) * 2);
+  --radius-3xl: calc(var(--radius) * 3);
+  --radius-4xl: calc(var(--radius) * 4);
+
+  --ease-smooth: ease;
+  --ease-in-quad: cubic-bezier(0.55, 0.085, 0.68, 0.53);
+  --ease-in-cubic: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+  --ease-in-quart: cubic-bezier(0.895, 0.03, 0.685, 0.22);
+  --ease-in-quint: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  --ease-in-circ: cubic-bezier(0.6, 0.04, 0.98, 0.335);
+  --ease-out-quad: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --ease-out-cubic: cubic-bezier(0.215, 0.61, 0.355, 1);
+  --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
+  --ease-out-quint: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-out-circ: cubic-bezier(0.075, 0.82, 0.165, 1);
+  --ease-out-fluid: cubic-bezier(0.32, 0.72, 0, 1);
+  --ease-in-out-quad: cubic-bezier(0.455, 0.03, 0.515, 0.955);
+  --ease-in-out-cubic: cubic-bezier(0.645, 0.045, 0.355, 1);
+  --ease-in-out-quart: cubic-bezier(0.77, 0, 0.175, 1);
+  --ease-in-out-quint: cubic-bezier(0.86, 0, 0.07, 1);
+  --ease-in-out-expo: cubic-bezier(1, 0, 0, 1);
+  --ease-in-out-circ: cubic-bezier(0.785, 0.135, 0.15, 0.86);
+  --ease-linear: linear;
+
+  --animate-spin-fast: spin 0.75s linear infinite;
+  --animate-skeleton: skeleton 2s linear infinite;
+  --animate-caret-blink: caret-blink 1.2s ease-out infinite;
+
+  /* 兼容旧 Tailwind 语义别名，避免迁移期间业务类名失效 */
   --color-card: var(--surface);
   --color-card-foreground: var(--surface-foreground);
   --color-popover: var(--overlay);
   --color-popover-foreground: var(--overlay-foreground);
-  --color-primary: var(--primary);
+  --color-primary: var(--accent);
   --color-primary-foreground: var(--accent-foreground);
   --color-secondary: var(--surface-tertiary);
   --color-secondary-foreground: var(--surface-tertiary-foreground);
-  --color-muted: var(--surface-tertiary);
   --color-muted-foreground: var(--muted);
-  --color-accent: var(--surface-hover);
-  --color-accent-foreground: var(--foreground);
   --color-destructive: var(--danger);
-  --color-border: var(--border);
   --color-input: var(--field-border);
   --color-ring: var(--focus);
+
+  @keyframes skeleton {
+    100% {
+      transform: translateX(200%);
+    }
+  }
+
+  @keyframes caret-blink {
+    0%,
+    70%,
+    100% {
+      opacity: 1;
+    }
+    20%,
+    50% {
+      opacity: 0;
+    }
+  }
+}
+
+@layer components {
+  .menu-item,
+  .list-box-item {
+    border-radius: var(--app-radius-interactive, var(--radius-2xl));
+  }
+
+  .popover .menu-item,
+  .popover .list-box-item,
+  .dropdown__popover .menu-item,
+  .select__popover .list-box-item,
+  .combo-box__popover .list-box-item,
+  .autocomplete__popover .list-box-item {
+    border-radius: var(--app-radius-popover-item, var(--radius-xl));
+  }
+
+  .dropdown__popover,
+  .select__popover,
+  .combo-box__popover,
+  .autocomplete__popover {
+    --app-popover-item-inset: 0.375rem;
+  }
+
+  .popover {
+    border-radius: var(--app-radius-popover, min(32px, var(--radius-3xl)));
+  }
+
+  .popover {
+    overflow: clip;
+  }
+
+  .popover__dialog {
+    padding: 0;
+  }
 }
 
 :root {
@@ -50,6 +231,7 @@
     'Segoe UI Emoji',
     'Segoe UI Symbol',
     'Noto Color Emoji';
+  --app-font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-family: var(--app-font-family);
   line-height: 1.5;
   font-weight: 400;

--- a/src/components/ChatPanel/ChatInput/style.module.less
+++ b/src/components/ChatPanel/ChatInput/style.module.less
@@ -87,11 +87,11 @@
 
 .toolbarPopover {
   padding: 0;
-  overflow: hidden;
   border: 1px solid var(--border-light);
-  border-radius: var(--radius-xl);
+  border-radius: var(--app-radius-popover, min(32px, var(--radius-3xl)));
   background: var(--overlay);
   box-shadow: var(--card-shadow);
+  overflow: clip;
 }
 
 .popoverPanel,
@@ -99,7 +99,7 @@
 .modelMenu {
   min-width: 220px;
   max-width: 340px;
-  padding: var(--space-xs);
+  padding: var(--app-popover-content-padding, var(--space-xs));
   background: var(--surface);
 }
 
@@ -116,7 +116,7 @@
 .deferredPopoverPanel {
   min-width: 220px;
   min-height: 72px;
-  padding: var(--space-xs);
+  padding: var(--app-popover-content-padding, var(--space-xs));
   background: var(--surface);
 }
 
@@ -139,6 +139,10 @@
 
 .listBox {
   background: transparent;
+
+  :global(.list-box-item) {
+    border-radius: var(--app-radius-popover-item, var(--radius-xl));
+  }
 }
 
 .listItemContent,
@@ -178,6 +182,7 @@
   min-height: 34px;
   padding: 6px var(--space-sm);
   border-top: 1px solid var(--border-light);
+  border-radius: var(--app-radius-popover-control, var(--radius-xl));
   color: var(--muted);
   font-size: var(--font-size-sm);
   cursor: pointer;
@@ -249,7 +254,7 @@
   height: 32px;
   padding: 0 var(--space-xs);
   border: 0;
-  border-radius: var(--radius);
+  border-radius: var(--app-radius-popover-control, var(--radius-xl));
   background: transparent;
   color: var(--text-tertiary);
   font-size: var(--font-size-sm);

--- a/src/components/ChatPanel/ModelSelector/style.module.less
+++ b/src/components/ChatPanel/ModelSelector/style.module.less
@@ -1,10 +1,11 @@
 // 全局样式变量
 .popoverBody {
+  --app-popover-item-inset: var(--app-popover-content-padding, var(--space-xs));
   padding: 0 !important;
   background-color: var(--overlay);
-  border-radius: var(--radius-xl);
+  border-radius: var(--app-radius-popover, min(32px, var(--radius-3xl)));
   box-shadow: var(--card-shadow);
-  overflow: hidden;
+  overflow: clip;
 }
 
 .selectorPanelDeferred {
@@ -32,7 +33,7 @@
   max-width: 100%;
   cursor: pointer;
   padding: 4px var(--space-xs);
-  border-radius: var(--radius);
+  border-radius: var(--app-radius-popover-control, var(--radius-xl));
   transition: all 0.2s;
   font-size: var(--font-size-sm);
   color: var(--text-tertiary);
@@ -77,7 +78,7 @@
       cursor: pointer;
       padding: 2px var(--space-xs);
       border: 1px solid var(--border-light);
-      border-radius: 6px;
+      border-radius: var(--radius-md);
       background-color: var(--surface);
       font-size: var(--font-size-sm);
       color: var(--foreground);
@@ -101,7 +102,7 @@
       cursor: pointer;
       padding: 2px var(--space-xs);
       border: 1px solid var(--border-light);
-      border-radius: 6px;
+      border-radius: var(--radius-md);
       background-color: var(--surface);
       font-size: var(--font-size-sm);
       color: var(--foreground);
@@ -123,14 +124,14 @@
   .modelList {
     max-height: 320px;
     overflow-y: auto;
-    padding: var(--space-xs);
+    padding: var(--app-popover-content-padding, var(--space-xs));
 
     &::-webkit-scrollbar {
       width: 4px;
     }
     &::-webkit-scrollbar-thumb {
       background-color: var(--surface-tertiary);
-      border-radius: 2px;
+      border-radius: var(--app-radius-scrollbar, var(--radius-xs));
     }
 
     // --- 列表项 (核心嵌套) ---
@@ -139,7 +140,7 @@
       align-items: center;
       padding: var(--space-xs) var(--space-sm);
       margin-bottom: 4px;
-      border-radius: var(--radius);
+      border-radius: var(--app-radius-popover-item, var(--radius-xl));
       cursor: pointer;
       transition: background 0.2s;
       line-height: 1;
@@ -227,7 +228,7 @@
             font-size: 10px;
             line-height: 16px;
             padding: 0 4px;
-            border-radius: 6px;
+            border-radius: var(--radius-md);
             display: flex;
             align-items: center;
           }
@@ -247,7 +248,7 @@
           background-color: var(--surface-secondary);
           height: 16px;
           padding: 0px 4px;
-          border-radius: 6px;
+          border-radius: var(--radius-md);
           display: flex;
           align-items: center;
         }

--- a/src/components/ChatPanel/popupSurface.module.less
+++ b/src/components/ChatPanel/popupSurface.module.less
@@ -4,15 +4,16 @@
 ﻿// src/components/ChatPanel/popupSurface.module.less
 
 .surface {
-  border-radius: var(--radius-xl);
+  --app-popover-item-inset: var(--app-popover-content-padding, var(--space-xs));
+  border-radius: var(--app-radius-popover, min(32px, var(--radius-3xl)));
   box-shadow: var(--card-shadow);
   background: var(--surface);
-  overflow: hidden;
+  overflow: clip;
 }
 
 .menu {
   background: var(--surface);
-  padding: var(--space-xs);
+  padding: var(--app-popover-content-padding, var(--space-xs));
   font-size: var(--font-size-sm);
   font-weight: 400;
 }
@@ -26,7 +27,7 @@
   margin: 0 0 2px;
   padding: 4px var(--space-sm);
   border: 0;
-  border-radius: var(--radius);
+  border-radius: var(--app-radius-popover-item, var(--radius-xl));
   background: transparent;
   color: var(--foreground);
   font: inherit;

--- a/src/components/_shadcn/message-scroller.tsx
+++ b/src/components/_shadcn/message-scroller.tsx
@@ -99,7 +99,7 @@ function MessageScrollerButton({
       data-size={size}
       direction={direction}
       className={cn(
-        'absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
+        'absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-surface-tertiary hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180',
         className
       )}
       render={

--- a/src/layouts/_common/Sidebar/AdminSidebar/style.module.less
+++ b/src/layouts/_common/Sidebar/AdminSidebar/style.module.less
@@ -10,6 +10,6 @@
 
   &::-webkit-scrollbar-thumb {
     background: var(--surface-tertiary);
-    border-radius: 2px;
+    border-radius: var(--app-radius-scrollbar, var(--radius-xs));
   }
 }

--- a/src/layouts/_common/Sidebar/AppSidebar/AppHeaderNav/style.module.less
+++ b/src/layouts/_common/Sidebar/AppSidebar/AppHeaderNav/style.module.less
@@ -30,7 +30,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  border-radius: 8px;
+  border-radius: var(--app-radius-interactive, var(--radius-2xl));
   padding: 0 12px;
   color: var(--muted);
   cursor: pointer;

--- a/src/layouts/_common/Sidebar/AppSidebar/AppSessionMenu/style.module.less
+++ b/src/layouts/_common/Sidebar/AppSidebar/AppSessionMenu/style.module.less
@@ -10,7 +10,7 @@
 
   &::-webkit-scrollbar-thumb {
     background: var(--surface-tertiary);
-    border-radius: 2px;
+    border-radius: var(--app-radius-scrollbar, var(--radius-xs));
   }
 }
 
@@ -52,7 +52,7 @@
   min-height: 40px;
   display: flex;
   align-items: center;
-  border-radius: 8px;
+  border-radius: var(--app-radius-interactive, var(--radius-2xl));
   padding: 0 12px;
   color: var(--muted);
   cursor: pointer;

--- a/src/layouts/_common/Sidebar/_common/UserProfile/style.module.less
+++ b/src/layouts/_common/Sidebar/_common/UserProfile/style.module.less
@@ -36,7 +36,7 @@
   min-height: 36px;
   padding: 0 12px;
   color: var(--muted);
-  border-radius: 8px;
+  border-radius: var(--app-radius-interactive, var(--radius-2xl));
   outline: none;
   cursor: pointer;
 
@@ -48,8 +48,8 @@
 
 .profileMenuItem[data-hovered],
 .profileMenuItem[data-focused],
-.profileMenu :global([data-slot='menu-item'][data-hovered]),
-.profileMenu :global([data-slot='menu-item'][data-focused]) {
+.profileMenu :global(.menu-item[data-hovered]),
+.profileMenu :global(.menu-item[data-focused]) {
   color: var(--foreground);
   background: var(--surface-tertiary) !important;
 }

--- a/src/theme/ThemeApplier.tsx
+++ b/src/theme/ThemeApplier.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 
 import { DEFAULT_COLOR_SCHEME, DEFAULT_HEROUI_THEME } from './constants';
 import { useColorScheme } from './useColorScheme';
+import { useThemeShape } from './useThemeShape';
 
 type ThemeApplierProps = {
   children: ReactNode;
@@ -13,6 +14,7 @@ type ThemeApplierProps = {
 export function ThemeApplier({ children, defaultTheme = DEFAULT_HEROUI_THEME }: ThemeApplierProps) {
   useTheme(defaultTheme);
   useColorScheme(DEFAULT_COLOR_SCHEME);
+  useThemeShape();
 
   return <>{children}</>;
 }

--- a/src/theme/constants.ts
+++ b/src/theme/constants.ts
@@ -25,10 +25,46 @@ export type ColorScheme = (typeof COLOR_SCHEME)[keyof typeof COLOR_SCHEME];
 
 export const DEFAULT_COLOR_SCHEME = COLOR_SCHEME.DEFAULT;
 
+/** HeroUI 主题页 Radius 配置 */
+export const THEME_RADIUS = {
+  NONE: 'none',
+  EXTRA_SMALL: 'extra-small',
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+} as const;
+
+export type ThemeRadius = (typeof THEME_RADIUS)[keyof typeof THEME_RADIUS];
+
+/** HeroUI 主题页 Radius Form 配置 */
+export const THEME_FORM_RADIUS = {
+  ...THEME_RADIUS,
+  EXTRA_LARGE: 'extra-large',
+} as const;
+
+export type ThemeFormRadius = (typeof THEME_FORM_RADIUS)[keyof typeof THEME_FORM_RADIUS];
+
+export const DEFAULT_THEME_RADIUS = THEME_RADIUS.MEDIUM;
+export const DEFAULT_THEME_FORM_RADIUS = THEME_FORM_RADIUS.LARGE;
+
 export interface ColorSchemeOption {
   id: ColorScheme;
   label: string;
   description: string;
+}
+
+export interface ThemeRadiusOption {
+  id: ThemeRadius;
+  label: string;
+  description: string;
+  cssValue: string;
+}
+
+export interface ThemeFormRadiusOption {
+  id: ThemeFormRadius;
+  label: string;
+  description: string;
+  cssValue: string;
 }
 
 export const COLOR_SCHEME_OPTIONS: ColorSchemeOption[] = [
@@ -68,4 +104,17 @@ export const THEME_MODE_OPTIONS: Array<{ id: ThemeMode; label: string; descripti
   { id: THEME_MODE.LIGHT, label: '浅色', description: '始终使用浅色界面' },
   { id: THEME_MODE.DARK, label: '深色', description: '始终使用深色界面' },
   { id: THEME_MODE.SYSTEM, label: '跟随系统', description: '随操作系统明暗设置切换' },
+];
+
+export const THEME_RADIUS_OPTIONS: ThemeRadiusOption[] = [
+  { id: THEME_RADIUS.NONE, label: '-', description: '0', cssValue: '0' },
+  { id: THEME_RADIUS.EXTRA_SMALL, label: 'XS', description: '2px', cssValue: '0.125rem' },
+  { id: THEME_RADIUS.SMALL, label: 'S', description: '4px', cssValue: '0.25rem' },
+  { id: THEME_RADIUS.MEDIUM, label: 'M', description: '8px', cssValue: '0.5rem' },
+  { id: THEME_RADIUS.LARGE, label: 'L', description: '12px', cssValue: '0.75rem' },
+];
+
+export const THEME_FORM_RADIUS_OPTIONS: ThemeFormRadiusOption[] = [
+  ...THEME_RADIUS_OPTIONS,
+  { id: THEME_FORM_RADIUS.EXTRA_LARGE, label: 'XL', description: '16px', cssValue: '1rem' },
 ];

--- a/src/theme/heroui/wisepen.css
+++ b/src/theme/heroui/wisepen.css
@@ -5,6 +5,18 @@
   [data-theme='light'],
   [data-theme='default'] {
     /* 默认 · 学术 light */
+    color-scheme: light;
+    --white: oklch(100% 0 0);
+    --black: oklch(0% 0 0);
+    --snow: oklch(0.9911 0 0);
+    --eclipse: oklch(0.2103 0.0059 285.89);
+    --spacing: 0.25rem;
+    --border-width: 1px;
+    --field-border-width: 0px;
+    --disabled-opacity: 0.5;
+    --ring-offset-width: 2px;
+    --cursor-interactive: pointer;
+    --cursor-disabled: not-allowed;
     --accent: #1e6f9f;
     --accent-foreground: #ffffff;
     --background: #f7f9fb;
@@ -22,7 +34,12 @@
     --muted: #6b7280;
     --overlay: #ffffff;
     --overlay-foreground: #111827;
-    --scrollbar: #e4e7ec;
+    --scrollbar: var(--scrollbar-thumb);
+    --scrollbar-thumb: color-mix(in oklch, var(--foreground) 15%, transparent);
+    --scrollbar-track: transparent;
+    --scrollbar-gutter: auto;
+    --scrollbar-width: thin;
+    --scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
     --segment: #ffffff;
     --segment-foreground: #111827;
     --separator: #e9ecef;
@@ -61,6 +78,16 @@
     --card-glow: 0 0 0 2px rgba(30, 111, 159, 0.15);
     --radius: 0.5rem;
     --field-radius: 0.75rem;
+    --surface-shadow:
+      0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
+      0 0 1px 0 rgba(0, 0, 0, 0.06);
+    --overlay-shadow:
+      0 2px 8px 0 rgba(0, 0, 0, 0.06), 0 -6px 12px 0 rgba(0, 0, 0, 0.03),
+      0 14px 28px 0 rgba(0, 0, 0, 0.08);
+    --field-shadow:
+      0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
+      0 0 1px 0 rgba(0, 0, 0, 0.06);
+    --backdrop: rgba(0, 0, 0, 0.5);
     --font-sans: var(--app-font-family);
   }
 
@@ -85,7 +112,12 @@
     --muted: #d1d5db;
     --overlay: #111827;
     --overlay-foreground: #f9fafb;
-    --scrollbar: #374151;
+    --scrollbar: var(--scrollbar-thumb);
+    --scrollbar-thumb: color-mix(in oklch, var(--foreground) 15%, transparent);
+    --scrollbar-track: transparent;
+    --scrollbar-gutter: auto;
+    --scrollbar-width: thin;
+    --scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
     --segment: #1f2937;
     --segment-foreground: #f9fafb;
     --separator: #2d3748;
@@ -122,6 +154,56 @@
     --card-surface: #111827;
     --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     --card-glow: 0 0 0 2px rgba(78, 168, 222, 0.3);
+    --surface-shadow: 0 0 0 0 transparent inset;
+    --overlay-shadow: 0 0 1px 0 rgba(255, 255, 255, 0.3) inset;
+    --field-shadow: 0 0 0 0 transparent inset;
+    --backdrop: rgba(0, 0, 0, 0.6);
+  }
+
+  /* HeroUI 主题页 Radius */
+  html[data-theme-radius='none'] {
+    --radius: 0;
+  }
+
+  html[data-theme-radius='extra-small'] {
+    --radius: 0.125rem;
+  }
+
+  html[data-theme-radius='small'] {
+    --radius: 0.25rem;
+  }
+
+  html[data-theme-radius='medium'] {
+    --radius: 0.5rem;
+  }
+
+  html[data-theme-radius='large'] {
+    --radius: 0.75rem;
+  }
+
+  /* HeroUI 主题页 Radius Form */
+  html[data-theme-form-radius='none'] {
+    --field-radius: 0;
+  }
+
+  html[data-theme-form-radius='extra-small'] {
+    --field-radius: 0.125rem;
+  }
+
+  html[data-theme-form-radius='small'] {
+    --field-radius: 0.25rem;
+  }
+
+  html[data-theme-form-radius='medium'] {
+    --field-radius: 0.5rem;
+  }
+
+  html[data-theme-form-radius='large'] {
+    --field-radius: 0.75rem;
+  }
+
+  html[data-theme-form-radius='extra-large'] {
+    --field-radius: 1rem;
   }
 
   /* warm */
@@ -586,7 +668,7 @@
     --line-height-xs: 18px;
     --line-height-2xs: 16px;
     --font-sans: var(--app-font-family);
-    --font-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+    --font-mono: var(--app-font-mono);
     --space-2xs: 4px;
     --space-xs: 8px;
     --space-sm: 12px;
@@ -594,14 +676,32 @@
     --space-lg: 24px;
     --space-xl: 32px;
     --space-2xl: 40px;
-    --radius-sm: 4px;
-    --radius-md: var(--radius);
-    --radius-lg: 8px;
+    --radius-xs: calc(var(--radius) * 0.25);
+    --radius-sm: calc(var(--radius) * 0.5);
+    --radius-md: calc(var(--radius) * 0.75);
+    --radius-lg: calc(var(--radius) * 1);
+    --radius-xl: calc(var(--radius) * 1.5);
+    --radius-2xl: calc(var(--radius) * 2);
+    --radius-3xl: calc(var(--radius) * 3);
+    --radius-4xl: calc(var(--radius) * 4);
     --radius-field: var(--field-radius);
+    --app-popover-content-padding: var(--space-xs);
+    --app-popover-item-inset: calc(var(--app-popover-content-padding) + var(--space-2xs));
+    --app-radius-sidebar-item: var(--radius-2xl);
+    --app-radius-popover: min(32px, var(--radius-3xl));
+    --app-radius-popover-item: min(
+      18px,
+      max(0px, calc(var(--app-radius-popover) - var(--app-popover-item-inset)))
+    );
+    --app-radius-popover-control: min(
+      16px,
+      max(0px, calc(var(--app-radius-popover) - var(--app-popover-content-padding)))
+    );
+    --app-radius-interactive: var(--app-radius-sidebar-item);
+    --app-radius-scrollbar: var(--radius-xs);
     --table-row-height: 52px;
     --row-height-comfortable: var(--table-row-height);
     --row-height-compact: var(--table-row-height);
-    --radius-xl: 12px;
 
     /* Table 布局 / 列宽（Less @table-* 经 table.module.less 引用） */
     --table-header-row-height: var(--table-row-height);
@@ -660,26 +760,56 @@
     --table-row-hover-bg: var(--surface-hover);
     --surface-muted: var(--surface-tertiary);
     --accent-hover: var(--primary-hover);
+    --background-secondary: color-mix(in oklab, var(--background) 96%, var(--foreground) 4%);
+    --background-tertiary: color-mix(in oklab, var(--background) 92%, var(--foreground) 8%);
+    --background-inverse: var(--foreground);
+    --default-hover: color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%);
+    --field-hover: color-mix(
+      in oklab,
+      var(--field-background, var(--default)) 90%,
+      var(--field-foreground, var(--foreground)) 2%
+    );
+    --field-focus: var(--field-background, var(--default));
+    --field-border-hover: color-mix(
+      in oklab,
+      var(--field-border, var(--border)) 88%,
+      var(--field-foreground, var(--foreground)) 10%
+    );
+    --field-border-focus: color-mix(
+      in oklab,
+      var(--field-border, var(--border)) 74%,
+      var(--field-foreground, var(--foreground)) 22%
+    );
+    --separator-secondary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
+    --separator-tertiary: color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%);
+    --border-secondary: color-mix(in oklab, var(--surface) 78%, var(--surface-foreground) 22%);
+    --border-tertiary: color-mix(in oklab, var(--surface) 66%, var(--surface-foreground) 34%);
     --accent-soft: color-mix(in srgb, var(--accent) 12%, transparent);
+    --accent-soft-foreground: color-mix(in oklab, var(--accent) 70%, var(--foreground) 30%);
+    --accent-soft-hover: color-mix(in oklab, var(--accent) 20%, transparent);
     --accent-softer: color-mix(in srgb, var(--accent) 8%, transparent);
     --accent-border: color-mix(in srgb, var(--accent) 32%, var(--border));
     --info-soft: color-mix(in srgb, var(--info) 12%, transparent);
     --warning-soft: color-mix(in srgb, var(--warning) 14%, transparent);
+    --warning-soft-foreground: color-mix(in oklab, var(--warning) 80%, var(--foreground) 70%);
+    --warning-soft-hover: color-mix(in oklab, var(--warning) 20%, transparent);
     --warning-border: color-mix(in srgb, var(--warning) 36%, var(--border));
     --error-soft: color-mix(in srgb, var(--error) 12%, transparent);
     --error-hover: color-mix(in srgb, var(--error) 88%, #000 12%);
     --error-border: color-mix(in srgb, var(--error) 36%, var(--border));
     --danger-soft: color-mix(in srgb, var(--danger) 12%, transparent);
+    --danger-soft-foreground: color-mix(in oklab, var(--danger) 70%, var(--foreground) 40%);
+    --danger-soft-hover: color-mix(in oklab, var(--danger) 20%, transparent);
     --danger-border: color-mix(in srgb, var(--danger) 36%, var(--border));
     --danger-hover: var(--error-hover);
     --success-soft: color-mix(in srgb, var(--success) 12%, transparent);
+    --success-soft-foreground: color-mix(in oklab, var(--success) 80%, var(--foreground) 60%);
+    --success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
     --success-hover: color-mix(in srgb, var(--success) 88%, #000 12%);
     --success-active: color-mix(in srgb, var(--success) 78%, #000 22%);
     --success-border: color-mix(in srgb, var(--success) 36%, var(--border));
-    --color-primary: var(--accent);
-    --color-warning: var(--warning);
-    --color-muted: var(--text-tertiary);
-    --color-muted-foreground: var(--muted);
-    --color-border: var(--border);
+    --default-soft: color-mix(in oklab, var(--default) 50%, transparent);
+    --default-soft-foreground: var(--default-foreground);
+    --default-soft-hover: color-mix(in oklab, var(--default) 60%, transparent);
   }
 }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,12 +3,23 @@ export {
   COLOR_SCHEME_OPTIONS,
   DEFAULT_COLOR_SCHEME,
   DEFAULT_HEROUI_THEME,
+  DEFAULT_THEME_FORM_RADIUS,
+  DEFAULT_THEME_RADIUS,
   HEROUI_SYSTEM_THEME,
+  THEME_FORM_RADIUS,
+  THEME_FORM_RADIUS_OPTIONS,
   THEME_MODE,
   THEME_MODE_OPTIONS,
+  THEME_RADIUS,
+  THEME_RADIUS_OPTIONS,
   type ColorScheme,
   type ColorSchemeOption,
+  type ThemeFormRadius,
+  type ThemeFormRadiusOption,
   type ThemeMode,
+  type ThemeRadius,
+  type ThemeRadiusOption,
 } from './constants';
 export { ThemeApplier } from './ThemeApplier';
 export { useColorScheme } from './useColorScheme';
+export { useThemeShape } from './useThemeShape';

--- a/src/theme/useThemeShape.ts
+++ b/src/theme/useThemeShape.ts
@@ -1,0 +1,85 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import {
+  DEFAULT_THEME_FORM_RADIUS,
+  DEFAULT_THEME_RADIUS,
+  THEME_FORM_RADIUS,
+  THEME_RADIUS,
+  type ThemeFormRadius,
+  type ThemeRadius,
+} from './constants';
+
+const THEME_RADIUS_STORAGE_KEY = 'heroui-theme-radius';
+const THEME_FORM_RADIUS_STORAGE_KEY = 'heroui-theme-form-radius';
+
+const THEME_RADIUS_VALUES = new Set<string>(Object.values(THEME_RADIUS));
+const THEME_FORM_RADIUS_VALUES = new Set<string>(Object.values(THEME_FORM_RADIUS));
+
+type ThemeShape = {
+  radius: ThemeRadius;
+  formRadius: ThemeFormRadius;
+};
+
+function isThemeRadius(value: string): value is ThemeRadius {
+  return THEME_RADIUS_VALUES.has(value);
+}
+
+function isThemeFormRadius(value: string): value is ThemeFormRadius {
+  return THEME_FORM_RADIUS_VALUES.has(value);
+}
+
+function readStoredThemeShape(defaultShape: ThemeShape): ThemeShape {
+  if (typeof window === 'undefined') return defaultShape;
+
+  const storedRadius = localStorage.getItem(THEME_RADIUS_STORAGE_KEY);
+  const storedFormRadius = localStorage.getItem(THEME_FORM_RADIUS_STORAGE_KEY);
+
+  return {
+    radius: storedRadius && isThemeRadius(storedRadius) ? storedRadius : defaultShape.radius,
+    formRadius:
+      storedFormRadius && isThemeFormRadius(storedFormRadius)
+        ? storedFormRadius
+        : defaultShape.formRadius,
+  };
+}
+
+function applyThemeShapeToDOM(shape: ThemeShape, previous: ThemeShape | undefined) {
+  if (previous?.radius !== shape.radius) {
+    document.documentElement.setAttribute('data-theme-radius', shape.radius);
+  }
+  if (previous?.formRadius !== shape.formRadius) {
+    document.documentElement.setAttribute('data-theme-form-radius', shape.formRadius);
+  }
+}
+
+/** localStorage 持久化，同时同步 HeroUI 圆角 token 到 documentElement */
+export function useThemeShape(
+  defaultShape: ThemeShape = {
+    radius: DEFAULT_THEME_RADIUS,
+    formRadius: DEFAULT_THEME_FORM_RADIUS,
+  }
+) {
+  const [themeShape, setThemeShape] = useState<ThemeShape>(() =>
+    readStoredThemeShape(defaultShape)
+  );
+  const appliedRef = useRef<ThemeShape | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    applyThemeShapeToDOM(themeShape, appliedRef.current);
+    appliedRef.current = themeShape;
+  }, [themeShape]);
+
+  const setRadius = (radius: ThemeRadius) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(THEME_RADIUS_STORAGE_KEY, radius);
+    setThemeShape((prev) => ({ ...prev, radius }));
+  };
+
+  const setFormRadius = (formRadius: ThemeFormRadius) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(THEME_FORM_RADIUS_STORAGE_KEY, formRadius);
+    setThemeShape((prev) => ({ ...prev, formRadius }));
+  };
+
+  return { ...themeShape, setRadius, setFormRadius };
+}

--- a/src/views/app/profile/Appearance/index.tsx
+++ b/src/views/app/profile/Appearance/index.tsx
@@ -1,22 +1,36 @@
 import {
+  Button,
   Card,
+  Chip,
+  Dropdown,
   Heading,
+  Input,
+  Label,
   Paragraph,
-  Radio,
-  RadioGroup,
+  ProgressBar,
   Separator,
+  Tabs,
+  TextField,
   ToggleButton,
   ToggleButtonGroup,
   useTheme,
 } from '@heroui/react';
+import { ChevronDown } from 'lucide-react';
 
 import {
   COLOR_SCHEME_OPTIONS,
+  THEME_FORM_RADIUS_OPTIONS,
   THEME_MODE_OPTIONS,
+  THEME_RADIUS_OPTIONS,
   useColorScheme,
+  useThemeShape,
   type ColorScheme,
   type ColorSchemeOption,
+  type ThemeFormRadius,
+  type ThemeFormRadiusOption,
   type ThemeMode,
+  type ThemeRadius,
+  type ThemeRadiusOption,
 } from '@/theme';
 
 import layout from '../style.module.less';
@@ -33,31 +47,22 @@ function ThemeModeSection({ value, onChange }: ThemeModeSectionProps) {
       <Heading level={3} className={layout.sectionTitle}>
         明暗模式
       </Heading>
-      <RadioGroup
-        aria-label="明暗模式"
-        className={styles.modeGroup}
-        value={value}
-        onChange={(next) => onChange(next as ThemeMode)}
+      <Tabs
+        className={styles.modeTabs}
+        selectedKey={value}
+        onSelectionChange={(next) => onChange(String(next) as ThemeMode)}
       >
-        {THEME_MODE_OPTIONS.map((option) => (
-          <Radio key={option.id} value={option.id} className={styles.modeOption}>
-            <Radio.Control>
-              <Radio.Indicator />
-            </Radio.Control>
-            <Radio.Content className={styles.modeContent}>
-              <span className={styles.modeLabel}>{option.label}</span>
-              <Paragraph
-                size="xs"
-                color="muted"
-                slot="description"
-                className={styles.modeDescription}
-              >
-                {option.description}
-              </Paragraph>
-            </Radio.Content>
-          </Radio>
-        ))}
-      </RadioGroup>
+        <Tabs.ListContainer className={styles.modeTabsListContainer}>
+          <Tabs.List className={styles.modeTabsList} aria-label="明暗模式">
+            {THEME_MODE_OPTIONS.map((option) => (
+              <Tabs.Tab key={option.id} id={option.id} className={styles.modeTab}>
+                {option.label}
+                <Tabs.Indicator />
+              </Tabs.Tab>
+            ))}
+          </Tabs.List>
+        </Tabs.ListContainer>
+      </Tabs>
     </section>
   );
 }
@@ -71,7 +76,7 @@ function ColorSchemeSection({ value, onChange }: ColorSchemeSectionProps) {
   return (
     <section className={styles.section}>
       <Heading level={3} className={layout.sectionTitle}>
-        主题配色
+        主题配色（Base / Accent）
       </Heading>
       <div className={styles.schemeGrid}>
         <ToggleButtonGroup
@@ -95,6 +100,76 @@ function ColorSchemeSection({ value, onChange }: ColorSchemeSectionProps) {
   );
 }
 
+type ThemeShapeSectionProps = {
+  radius: ThemeRadius;
+  formRadius: ThemeFormRadius;
+  onRadiusChange: (radius: ThemeRadius) => void;
+  onFormRadiusChange: (radius: ThemeFormRadius) => void;
+};
+
+function ThemeShapeSection({
+  radius,
+  formRadius,
+  onRadiusChange,
+  onFormRadiusChange,
+}: ThemeShapeSectionProps) {
+  return (
+    <section className={styles.section}>
+      <Heading level={3} className={layout.sectionTitle}>
+        圆角
+      </Heading>
+      <div className={styles.shapeControls}>
+        <ShapeOptionGroup
+          label="Radius"
+          value={radius}
+          options={THEME_RADIUS_OPTIONS}
+          onChange={(next) => onRadiusChange(next as ThemeRadius)}
+        />
+        <ShapeOptionGroup
+          label="Radius Form"
+          value={formRadius}
+          options={THEME_FORM_RADIUS_OPTIONS}
+          onChange={(next) => onFormRadiusChange(next as ThemeFormRadius)}
+        />
+      </div>
+    </section>
+  );
+}
+
+type ShapeOptionGroupProps = {
+  label: string;
+  value: ThemeRadius | ThemeFormRadius;
+  options: Array<ThemeRadiusOption | ThemeFormRadiusOption>;
+  onChange: (radius: ThemeRadius | ThemeFormRadius) => void;
+};
+
+function ShapeOptionGroup({ label, value, options, onChange }: ShapeOptionGroupProps) {
+  return (
+    <div className={styles.shapeGroupBlock}>
+      <span className={styles.shapeGroupLabel}>{label}</span>
+      <ToggleButtonGroup
+        aria-label={label}
+        selectionMode="single"
+        selectedKeys={new Set([value])}
+        onSelectionChange={(keys) => {
+          const [key] = [...keys];
+          if (key != null) onChange(String(key) as ThemeRadius | ThemeFormRadius);
+        }}
+        className={styles.shapeGroup}
+        orientation="horizontal"
+        isDetached
+      >
+        {options.map((option) => (
+          <ToggleButton key={option.id} id={option.id} className={styles.shapeOption}>
+            <span className={styles.shapeLabel}>{option.label}</span>
+            <span className={styles.shapeValue}>{option.description}</span>
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </div>
+  );
+}
+
 type SchemeOptionProps = {
   option: ColorSchemeOption;
 };
@@ -109,6 +184,82 @@ function SchemeOption({ option }: SchemeOptionProps) {
       <span className={styles.schemeLabel}>{option.label}</span>
       <span className={styles.schemeDescription}>{option.description}</span>
     </ToggleButton>
+  );
+}
+
+function ThemePreviewSection() {
+  return (
+    <section className={styles.section}>
+      <Heading level={3} className={layout.sectionTitle}>
+        主题验证
+      </Heading>
+      <div className={styles.previewGrid}>
+        <Card className={styles.previewCard}>
+          <Card.Header className={styles.previewHeader}>
+            <Card.Title>HeroUI 组件</Card.Title>
+            <Chip size="sm" variant="soft">
+              <Chip.Label>Soft</Chip.Label>
+            </Chip>
+          </Card.Header>
+          <Card.Content className={styles.previewBody}>
+            <div className={styles.previewActions}>
+              <Button variant="primary">Primary</Button>
+              <Button variant="secondary">Secondary</Button>
+              <Dropdown>
+                <Dropdown.Trigger>
+                  <Button variant="tertiary">
+                    菜单
+                    <ChevronDown size={14} />
+                  </Button>
+                </Dropdown.Trigger>
+                <Dropdown.Popover>
+                  <Dropdown.Menu aria-label="主题验证菜单">
+                    <Dropdown.Item key="edit">编辑</Dropdown.Item>
+                    <Dropdown.Item key="copy">复制</Dropdown.Item>
+                  </Dropdown.Menu>
+                </Dropdown.Popover>
+              </Dropdown>
+            </div>
+            <TextField aria-label="主题验证输入框" className={styles.previewField}>
+              <Label>输入框</Label>
+              <Input placeholder="Radius Form 控制这里" />
+            </TextField>
+            <ProgressBar
+              aria-label="主题验证进度"
+              value={64}
+              valueLabel="64%"
+              className={styles.previewProgress}
+            >
+              <ProgressBar.Track>
+                <ProgressBar.Fill />
+              </ProgressBar.Track>
+              <ProgressBar.Output />
+            </ProgressBar>
+          </Card.Content>
+        </Card>
+
+        <div className={styles.previewDialog}>
+          <div className={styles.previewDialogHeader}>
+            <span>Modal / Table 外壳</span>
+            <span className={styles.previewDialogBadge}>Token</span>
+          </div>
+          <div className={styles.previewTable}>
+            <div className={styles.previewTableRow}>
+              <span>Button</span>
+              <span>--radius-3xl</span>
+            </div>
+            <div className={styles.previewTableRow}>
+              <span>Input</span>
+              <span>--radius-field</span>
+            </div>
+            <div className={styles.previewTableRow}>
+              <span>Table</span>
+              <span>--table-shell-radius</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -128,6 +279,7 @@ function AppearanceHeader() {
 function Appearance() {
   const { theme, setTheme } = useTheme();
   const { colorScheme, setColorScheme } = useColorScheme();
+  const { radius, formRadius, setRadius, setFormRadius } = useThemeShape();
 
   return (
     <div className={layout.pageContainer}>
@@ -137,6 +289,15 @@ function Appearance() {
           <ThemeModeSection value={theme} onChange={setTheme} />
           <Separator className={styles.divider} />
           <ColorSchemeSection value={colorScheme} onChange={setColorScheme} />
+          <Separator className={styles.divider} />
+          <ThemeShapeSection
+            radius={radius}
+            formRadius={formRadius}
+            onRadiusChange={setRadius}
+            onFormRadiusChange={setFormRadius}
+          />
+          <Separator className={styles.divider} />
+          <ThemePreviewSection />
         </Card.Content>
       </Card>
     </div>

--- a/src/views/app/profile/Appearance/style.module.less
+++ b/src/views/app/profile/Appearance/style.module.less
@@ -20,37 +20,22 @@
   margin: var(--space-xs, 8px) 0;
 }
 
-.modeGroup {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-sm, 12px);
+.modeTabs {
+  width: 100%;
 }
 
-.modeOption {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-sm, 12px);
-  padding: var(--space-sm, 12px) var(--space-md, 16px);
-  border: 1px solid var(--border);
-  border-radius: var(--radius, 8px);
-  background: var(--surface);
-  cursor: pointer;
+.modeTabsListContainer,
+.modeTabsList {
+  width: 100%;
 }
 
-.modeContent {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs, 4px);
+.modeTabsList {
+  max-width: 24rem;
 }
 
-.modeLabel {
-  font-weight: 500;
-  color: var(--foreground);
-}
-
-.modeDescription {
-  font-size: var(--font-size-sm, 13px);
-  color: var(--muted);
+.modeTab {
+  min-width: 0;
+  white-space: nowrap;
 }
 
 .schemeGrid {
@@ -111,4 +96,164 @@
 .schemeDescription {
   font-size: var(--font-size-sm, 12px);
   color: var(--muted);
+}
+
+.shapeGroupBlock {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-xs, 8px);
+}
+
+.shapeControls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-md, 16px);
+  align-items: start;
+}
+
+.shapeGroupLabel {
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.shapeGroup {
+  display: flex;
+  overflow-x: auto;
+  gap: var(--space-xs, 8px);
+  padding-bottom: 2px;
+}
+
+.shapeOption:global(.toggle-button) {
+  display: flex;
+  flex: 0 0 4.5rem;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+  width: 4.5rem;
+  height: auto;
+  min-height: 3rem;
+  padding: var(--space-xs, 8px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-field);
+  background: var(--surface);
+
+  &[data-selected='true'],
+  &[aria-pressed='true'] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent-soft-foreground);
+  }
+}
+
+.shapeLabel {
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 600;
+}
+
+.shapeValue {
+  font-size: var(--font-size-xs, 12px);
+  color: var(--muted);
+}
+
+.previewGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.72fr);
+  gap: var(--space-md, 16px);
+}
+
+.previewCard {
+  min-width: 0;
+}
+
+.previewHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm, 12px);
+}
+
+.previewBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 16px);
+}
+
+.previewActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs, 8px);
+}
+
+.previewField {
+  max-width: 22rem;
+}
+
+.previewProgress {
+  max-width: 22rem;
+}
+
+.previewDialog {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-3xl);
+  background: var(--overlay);
+  box-shadow: var(--overlay-shadow);
+}
+
+.previewDialogHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-xs, 8px);
+  padding: var(--space-md, 16px);
+  font-size: var(--font-size-sm, 14px);
+  font-weight: 600;
+  color: var(--overlay-foreground);
+}
+
+.previewDialogBadge {
+  border-radius: var(--radius-field);
+  background: var(--default-soft);
+  padding: 2px var(--space-xs, 8px);
+  font-size: var(--font-size-xs, 12px);
+  color: var(--default-soft-foreground);
+}
+
+.previewTable {
+  margin: 0 var(--space-md, 16px) var(--space-md, 16px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--table-shell-radius);
+}
+
+.previewTableRow {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1fr);
+  gap: var(--space-sm, 12px);
+  padding: var(--space-sm, 12px);
+  font-size: var(--font-size-sm, 14px);
+  color: var(--foreground);
+
+  & + & {
+    border-top: 1px solid var(--separator);
+  }
+
+  span:last-child {
+    color: var(--muted);
+  }
+}
+
+@media (max-width: 820px) {
+  .previewGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .shapeControls {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## 变更
- 扩展 HeroUI 主题 token，补齐 Radius / Radius Form 与通用颜色、阴影、状态色映射
- 新增主题形状设置持久化，将圆角配置同步到 html data attribute
- 调整 Appearance 页面，增加圆角配置与主题预览，并将明暗模式改为 Tabs
- 修复 sidebar、popover、menu/listbox hover 与 selected 状态圆角不跟随主题的问题，并处理 popover 大圆角溢出

## 验证
- pnpm lint
- git diff --check
- pnpm exec vite build

## 备注
- pnpm typecheck 当前被工作区未纳入本 PR 的 Resource/Tag 领域类型改动阻塞，非本次样式改造引起。