### PR TITLE
feat: 重构 Note 工具栏与表格交互

### DIFF
--- a/src/components/Note/CustomBlockNote/index.tsx
+++ b/src/components/Note/CustomBlockNote/index.tsx
@@ -29,6 +29,7 @@ import {
 } from 'react';
 import NoteSideMenu from '../NoteSideMenu';
 import NoteSlashMenu from '../NoteSlashMenu';
+import NoteTableHandles from '../NoteTableHandles';
 import NoteToolbar from '../NoteToolbar';
 import { hasAiDiffContentFromEditor } from './AiDiffPresence';
 import { blockNoteSchema, type CustomBlockNoteEditor } from './blockNoteSchema';
@@ -753,6 +754,7 @@ function CustomBlockNoteEditor({
               formattingToolbar={false}
               slashMenu={false}
               sideMenu={false}
+              tableHandles={false}
               comments={false}
               editable={!readOnly}
               onSelectionChange={handleSelectionChange}
@@ -766,7 +768,8 @@ function CustomBlockNoteEditor({
                 }}
               />
               <NoteSlashMenu editor={editor} plugins={plugins} />
-              <NoteSideMenu />
+              <NoteSideMenu plugins={plugins} />
+              <NoteTableHandles />
               {showCommentsUi ? (
                 <NoteCommentsUi
                   editor={editor}

--- a/src/components/Note/CustomBlockNote/index.tsx
+++ b/src/components/Note/CustomBlockNote/index.tsx
@@ -27,6 +27,7 @@ import {
   type CSSProperties,
   type Ref,
 } from 'react';
+import NoteSideMenu from '../NoteSideMenu';
 import NoteSlashMenu from '../NoteSlashMenu';
 import NoteToolbar from '../NoteToolbar';
 import { hasAiDiffContentFromEditor } from './AiDiffPresence';
@@ -751,6 +752,7 @@ function CustomBlockNoteEditor({
               theme="light"
               formattingToolbar={false}
               slashMenu={false}
+              sideMenu={false}
               comments={false}
               editable={!readOnly}
               onSelectionChange={handleSelectionChange}
@@ -764,6 +766,7 @@ function CustomBlockNoteEditor({
                 }}
               />
               <NoteSlashMenu editor={editor} plugins={plugins} />
+              <NoteSideMenu />
               {showCommentsUi ? (
                 <NoteCommentsUi
                   editor={editor}

--- a/src/components/Note/CustomBlockNote/style.module.less
+++ b/src/components/Note/CustomBlockNote/style.module.less
@@ -24,6 +24,53 @@
     font-family: var(--app-font-family);
   }
 
+  :global(.bn-container) {
+    --bn-colors-editor-text: var(--foreground);
+    --bn-colors-editor-background: transparent;
+    --bn-colors-menu-text: var(--overlay-foreground);
+    --bn-colors-menu-background: var(--overlay);
+    --bn-colors-tooltip-text: var(--overlay-foreground);
+    --bn-colors-tooltip-background: var(--overlay);
+    --bn-colors-hovered-text: var(--surface-secondary-foreground);
+    --bn-colors-hovered-background: var(--surface-secondary);
+    --bn-colors-selected-text: var(--accent-soft-foreground);
+    --bn-colors-selected-background: var(--accent-soft);
+    --bn-colors-disabled-text: var(--text-disabled);
+    --bn-colors-disabled-background: var(--default-soft);
+    --bn-colors-shadow: transparent;
+    --bn-colors-border: var(--border-light);
+    --bn-colors-side-menu: var(--muted);
+    --bn-shadow-medium: var(--overlay-shadow);
+    --bn-shadow-light: var(--surface-shadow);
+    --bn-border: 1px solid var(--border-light);
+    --bn-border-radius: var(--radius-md);
+    --bn-ui-base-z-index: 100;
+
+    --mantine-primary-color-filled: var(--accent);
+    --mantine-primary-color-filled-hover: var(--accent-hover);
+    --mantine-primary-color-light: var(--accent-soft);
+    --mantine-primary-color-light-hover: var(--accent-soft-hover);
+    --mantine-primary-color-light-color: var(--accent);
+  }
+
+  :global(.bn-block-content.ProseMirror-selectednode > *),
+  :global(.ProseMirror-selectednode > .bn-block-content > *) {
+    outline-color: var(--accent) !important;
+  }
+
+  :global(.ProseMirror .selectedCell::after) {
+    background: var(--accent-soft);
+  }
+
+  :global(.ProseMirror .column-resize-handle),
+  :global(.bn-table-drop-cursor) {
+    background-color: var(--accent);
+  }
+
+  :global([data-show-selection]) {
+    background-color: var(--accent-soft);
+  }
+
   /* 修改侧边栏把手居中对齐 */
   :global(.bn-container .bn-side-menu) {
     height: auto !important;

--- a/src/components/Note/NoteEditorMenus/blockTypes.tsx
+++ b/src/components/Note/NoteEditorMenus/blockTypes.tsx
@@ -1,0 +1,184 @@
+import type { CustomBlockNoteEditor } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { editorHasBlockWithType } from '@blocknote/core';
+import {
+  Braces,
+  CheckSquare,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  List,
+  ListOrdered,
+  ListTree,
+  TextQuote,
+  Type,
+  type LucideIcon,
+} from 'lucide-react';
+import { isRecord, toBlockUpdate, type NoteBlock, type NotePartialBlock } from './utils';
+
+export type BlockTypeProps = Record<string, boolean | number | string>;
+
+export interface BlockTypeMenuItem {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  type: string;
+  props?: BlockTypeProps;
+}
+
+export const primaryBlockTypeItems: BlockTypeMenuItem[] = [
+  { key: 'paragraph', label: '正文', icon: Type, type: 'paragraph' },
+  {
+    key: 'heading-1',
+    label: '一级标题',
+    icon: Heading1,
+    type: 'heading',
+    props: { level: 1, isToggleable: false },
+  },
+  {
+    key: 'heading-2',
+    label: '二级标题',
+    icon: Heading2,
+    type: 'heading',
+    props: { level: 2, isToggleable: false },
+  },
+  {
+    key: 'heading-3',
+    label: '三级标题',
+    icon: Heading3,
+    type: 'heading',
+    props: { level: 3, isToggleable: false },
+  },
+  { key: 'numbered-list', label: '有序列表', icon: ListOrdered, type: 'numberedListItem' },
+  { key: 'bullet-list', label: '无序列表', icon: List, type: 'bulletListItem' },
+  { key: 'check-list', label: '任务', icon: CheckSquare, type: 'checkListItem' },
+  { key: 'code-block', label: '代码块', icon: Braces, type: 'codeBlock' },
+  { key: 'quote', label: '引用', icon: TextQuote, type: 'quote' },
+  { key: 'toggle-list', label: '折叠列表', icon: ListTree, type: 'toggleListItem' },
+];
+
+export const moreHeadingItems: BlockTypeMenuItem[] = [
+  {
+    key: 'heading-4',
+    label: '四级标题',
+    icon: Heading4,
+    type: 'heading',
+    props: { level: 4, isToggleable: false },
+  },
+  {
+    key: 'heading-5',
+    label: '五级标题',
+    icon: Heading5,
+    type: 'heading',
+    props: { level: 5, isToggleable: false },
+  },
+  {
+    key: 'heading-6',
+    label: '六级标题',
+    icon: Heading6,
+    type: 'heading',
+    props: { level: 6, isToggleable: false },
+  },
+  {
+    key: 'toggle-heading-1',
+    label: '可折叠一级标题',
+    icon: Heading1,
+    type: 'heading',
+    props: { level: 1, isToggleable: true },
+  },
+  {
+    key: 'toggle-heading-2',
+    label: '可折叠二级标题',
+    icon: Heading2,
+    type: 'heading',
+    props: { level: 2, isToggleable: true },
+  },
+  {
+    key: 'toggle-heading-3',
+    label: '可折叠三级标题',
+    icon: Heading3,
+    type: 'heading',
+    props: { level: 3, isToggleable: true },
+  },
+];
+
+const quickBlockTypeKeys = new Set([
+  'paragraph',
+  'heading-1',
+  'heading-2',
+  'heading-3',
+  'numbered-list',
+  'bullet-list',
+  'check-list',
+  'code-block',
+  'quote',
+  'toggle-list',
+]);
+
+function toPropTypeMap(props?: BlockTypeProps) {
+  if (!props) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(props).map(([key, value]) => [key, typeof value])
+  ) as Record<string, 'boolean' | 'number' | 'string'>;
+}
+
+export function isBlockTypeItemAvailable(editor: CustomBlockNoteEditor, item: BlockTypeMenuItem) {
+  const propTypes = toPropTypeMap(item.props);
+  return propTypes
+    ? editorHasBlockWithType(editor, item.type, propTypes)
+    : editorHasBlockWithType(editor, item.type);
+}
+
+export function blockMatchesBlockTypeItem(
+  block: NoteBlock | undefined,
+  item: BlockTypeMenuItem
+): boolean {
+  if (!block || block.type !== item.type) {
+    return false;
+  }
+  const props = isRecord(block.props) ? block.props : {};
+  return Object.entries(item.props ?? {}).every(([key, value]) => props[key] === value);
+}
+
+export function getAvailableBlockTypeItems(editor: CustomBlockNoteEditor) {
+  const primaryItems = primaryBlockTypeItems.filter((item) =>
+    isBlockTypeItemAvailable(editor, item)
+  );
+  const headingItems = moreHeadingItems.filter((item) => isBlockTypeItemAvailable(editor, item));
+
+  return {
+    primaryItems,
+    headingItems,
+    allItems: [...primaryItems, ...headingItems],
+    quickItems: primaryItems.filter((item) => quickBlockTypeKeys.has(item.key)),
+  };
+}
+
+export function applyBlockTypeToBlocks(
+  editor: CustomBlockNoteEditor,
+  blocks: NoteBlock[],
+  item: BlockTypeMenuItem
+) {
+  editor.transact(() => {
+    for (const block of blocks) {
+      editor.updateBlock(
+        block,
+        toBlockUpdate({
+          type: item.type,
+          props: item.props,
+        })
+      );
+    }
+  });
+}
+
+export function blockTypeItemToPartialBlock(item: BlockTypeMenuItem): NotePartialBlock {
+  return {
+    type: item.type,
+    props: item.props,
+  } as NotePartialBlock;
+}

--- a/src/components/Note/NoteEditorMenus/colorPalette.tsx
+++ b/src/components/Note/NoteEditorMenus/colorPalette.tsx
@@ -1,0 +1,109 @@
+import { Button, ColorSwatchPicker } from '@heroui/react';
+import clsx from 'clsx';
+import { Baseline } from 'lucide-react';
+import {
+  colorItems,
+  findColorItemByPickerValue,
+  getColorItem,
+  type ColorKey,
+} from './colorPaletteData';
+import styles from './style.module.less';
+
+interface ColorPaletteSectionConfig {
+  color?: string;
+  onChange: (color: ColorKey) => void;
+}
+
+interface ColorPaletteContentProps {
+  text?: ColorPaletteSectionConfig;
+  background?: ColorPaletteSectionConfig;
+  onReset?: () => void;
+  className?: string;
+}
+
+function ColorSection({
+  title,
+  selectedColor,
+  mode,
+  onSelect,
+}: {
+  title: string;
+  selectedColor?: string;
+  mode: 'text' | 'background';
+  onSelect: (color: ColorKey) => void;
+}) {
+  const selectedItem = getColorItem(selectedColor);
+
+  return (
+    <div className={styles.colorSection}>
+      <div className={styles.colorSectionTitle}>{title}</div>
+      <ColorSwatchPicker
+        aria-label={title}
+        className={styles.colorSwatchPicker}
+        layout="grid"
+        value={selectedItem.value}
+        onChange={(color) => {
+          const item = findColorItemByPickerValue(color.toString('hex'));
+          if (item) {
+            onSelect(item.key);
+          }
+        }}
+      >
+        {colorItems.map((item) => (
+          <ColorSwatchPicker.Item
+            key={`${mode}-${item.key}`}
+            color={item.value}
+            aria-label={`${title}${item.label}`}
+            className={({ isSelected }) =>
+              clsx(styles.colorSwatchItem, isSelected && styles.colorSwatchSelected)
+            }
+            onPress={() => onSelect(item.key)}
+          >
+            {mode === 'text' ? (
+              <Baseline
+                size={20}
+                className={clsx(styles.colorTextPreview, item.textClassName)}
+                aria-hidden="true"
+              />
+            ) : (
+              <span className={clsx(styles.colorBackgroundPreview, item.backgroundClassName)} />
+            )}
+          </ColorSwatchPicker.Item>
+        ))}
+      </ColorSwatchPicker>
+    </div>
+  );
+}
+
+export function ColorPaletteContent({
+  text,
+  background,
+  onReset,
+  className,
+}: ColorPaletteContentProps) {
+  return (
+    <div className={clsx(styles.colorPanel, className)}>
+      {text ? (
+        <ColorSection
+          title="字体颜色"
+          selectedColor={text.color}
+          mode="text"
+          onSelect={text.onChange}
+        />
+      ) : null}
+      {background ? (
+        <ColorSection
+          title="背景颜色"
+          selectedColor={background.color}
+          mode="background"
+          onSelect={background.onChange}
+        />
+      ) : null}
+      {onReset ? (
+        <Button variant="outline" size="sm" className={styles.resetColorButton} onPress={onReset}>
+          恢复默认
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/Note/NoteEditorMenus/colorPaletteData.ts
+++ b/src/components/Note/NoteEditorMenus/colorPaletteData.ts
@@ -1,0 +1,100 @@
+import styles from './style.module.less';
+
+export type ColorKey =
+  'default' | 'gray' | 'brown' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink';
+
+export interface ColorItem {
+  key: ColorKey;
+  label: string;
+  value: string;
+  textClassName: string;
+  backgroundClassName: string;
+}
+
+export const colorItems: ColorItem[] = [
+  {
+    key: 'default',
+    label: '默认',
+    value: '#111827',
+    textClassName: styles.textDefault,
+    backgroundClassName: styles.backgroundDefault,
+  },
+  {
+    key: 'gray',
+    label: '灰色',
+    value: '#9b9a97',
+    textClassName: styles.textGray,
+    backgroundClassName: styles.backgroundGray,
+  },
+  {
+    key: 'brown',
+    label: '棕色',
+    value: '#64473a',
+    textClassName: styles.textBrown,
+    backgroundClassName: styles.backgroundBrown,
+  },
+  {
+    key: 'red',
+    label: '红色',
+    value: '#e03e3e',
+    textClassName: styles.textRed,
+    backgroundClassName: styles.backgroundRed,
+  },
+  {
+    key: 'orange',
+    label: '橙色',
+    value: '#d9730d',
+    textClassName: styles.textOrange,
+    backgroundClassName: styles.backgroundOrange,
+  },
+  {
+    key: 'yellow',
+    label: '黄色',
+    value: '#dfab01',
+    textClassName: styles.textYellow,
+    backgroundClassName: styles.backgroundYellow,
+  },
+  {
+    key: 'green',
+    label: '绿色',
+    value: '#4d6461',
+    textClassName: styles.textGreen,
+    backgroundClassName: styles.backgroundGreen,
+  },
+  {
+    key: 'blue',
+    label: '蓝色',
+    value: '#0b6e99',
+    textClassName: styles.textBlue,
+    backgroundClassName: styles.backgroundBlue,
+  },
+  {
+    key: 'purple',
+    label: '紫色',
+    value: '#6940a5',
+    textClassName: styles.textPurple,
+    backgroundClassName: styles.backgroundPurple,
+  },
+  {
+    key: 'pink',
+    label: '粉色',
+    value: '#ad1a72',
+    textClassName: styles.textPink,
+    backgroundClassName: styles.backgroundPink,
+  },
+];
+
+export function normalizeColor(color: string | undefined): ColorKey {
+  const value = color ?? 'default';
+  return colorItems.some((item) => item.key === value) ? (value as ColorKey) : 'default';
+}
+
+export function getColorItem(color: string | undefined) {
+  const safeColor = normalizeColor(color);
+  return colorItems.find((item) => item.key === safeColor) ?? colorItems[0];
+}
+
+export function findColorItemByPickerValue(value: string) {
+  const normalizedValue = value.toLowerCase();
+  return colorItems.find((item) => item.value.toLowerCase() === normalizedValue);
+}

--- a/src/components/Note/NoteEditorMenus/style.module.less
+++ b/src/components/Note/NoteEditorMenus/style.module.less
@@ -1,0 +1,151 @@
+.colorPanel {
+  --note-color-swatch-size: var(--control-height-sm);
+  --note-color-swatch-columns: 10;
+
+  width: max-content;
+  padding: var(--space-md);
+}
+
+.colorSection + .colorSection {
+  margin-top: var(--space-sm);
+}
+
+.colorSectionTitle {
+  margin-bottom: var(--space-xs);
+  color: var(--muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.colorSwatchPicker {
+  display: grid;
+  grid-template-columns: repeat(var(--note-color-swatch-columns), var(--note-color-swatch-size));
+  gap: var(--space-xs);
+}
+
+.colorSwatchItem {
+  width: var(--note-color-swatch-size);
+  height: var(--note-color-swatch-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  cursor: pointer;
+}
+
+.colorSwatchItem:hover,
+.colorSwatchItem[data-hovered],
+.colorSwatchSelected {
+  border-color: var(--primary);
+}
+
+.colorSwatchSelected {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 22%, transparent);
+}
+
+.colorTextPreview {
+  flex-shrink: 0;
+}
+
+.colorBackgroundPreview {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: var(--radius-sm);
+}
+
+.backgroundDefault {
+  background:
+    linear-gradient(
+      135deg,
+      transparent 48%,
+      var(--primary) 49%,
+      var(--primary) 51%,
+      transparent 52%
+    ),
+    var(--surface);
+}
+
+.textDefault {
+  color: var(--overlay-foreground);
+}
+
+.textGray {
+  color: #9b9a97;
+}
+
+.textBrown {
+  color: #64473a;
+}
+
+.textRed {
+  color: #e03e3e;
+}
+
+.textOrange {
+  color: #d9730d;
+}
+
+.textYellow {
+  color: #dfab01;
+}
+
+.textGreen {
+  color: #4d6461;
+}
+
+.textBlue {
+  color: #0b6e99;
+}
+
+.textPurple {
+  color: #6940a5;
+}
+
+.textPink {
+  color: #ad1a72;
+}
+
+.backgroundGray {
+  background: #ebeced;
+}
+
+.backgroundBrown {
+  background: #e9e5e3;
+}
+
+.backgroundRed {
+  background: #fbe4e4;
+}
+
+.backgroundOrange {
+  background: #f6e9d9;
+}
+
+.backgroundYellow {
+  background: #fbf3db;
+}
+
+.backgroundGreen {
+  background: #ddedea;
+}
+
+.backgroundBlue {
+  background: #ddebf1;
+}
+
+.backgroundPurple {
+  background: #eae4f2;
+}
+
+.backgroundPink {
+  background: #f4dfeb;
+}
+
+.resetColorButton {
+  width: 100%;
+  margin-top: var(--space-md);
+}

--- a/src/components/Note/NoteEditorMenus/utils.ts
+++ b/src/components/Note/NoteEditorMenus/utils.ts
@@ -1,0 +1,17 @@
+import type { CustomBlockNoteEditor } from '../CustomBlockNote/blockNoteSchema';
+
+export type NoteBlock = ReturnType<CustomBlockNoteEditor['getTextCursorPosition']>['block'];
+export type NoteBlockUpdate = Parameters<CustomBlockNoteEditor['updateBlock']>[1];
+export type NotePartialBlock = Parameters<CustomBlockNoteEditor['insertBlocks']>[0][number];
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function toBlockUpdate(update: {
+  type?: string;
+  props?: Record<string, unknown>;
+  content?: unknown;
+}): NoteBlockUpdate {
+  return update as NoteBlockUpdate;
+}

--- a/src/components/Note/NoteSideMenu/index.tsx
+++ b/src/components/Note/NoteSideMenu/index.tsx
@@ -1,10 +1,10 @@
 import type { CustomBlockNoteEditor } from '@/components/Note/CustomBlockNote/blockNoteSchema';
 import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
 import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
+import type { NoteEditorPlugin } from '@/components/Note/CustomBlockNote/plugins/types';
 import {
   applyBlockTypeToBlocks,
   blockMatchesBlockTypeItem,
-  blockTypeItemToPartialBlock,
   getAvailableBlockTypeItems,
   type BlockTypeMenuItem,
 } from '@/components/Note/NoteEditorMenus/blockTypes';
@@ -16,8 +16,25 @@ import {
   type NoteBlock,
   type NotePartialBlock,
 } from '@/components/Note/NoteEditorMenus/utils';
-import { blockHasType, defaultProps, editorHasBlockWithType } from '@blocknote/core';
+import {
+  NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET,
+  getNoteSlashMenuItems,
+} from '@/components/Note/NoteSlashMenu/buildSlashMenuItems';
+import {
+  resolveSlashMenuGroup,
+  sortSuggestionItemsForDisplay,
+} from '@/components/Note/NoteSlashMenu/slashMenuModel';
+import { SlashMenuDropdownItems } from '@/components/Note/NoteSlashMenu/slashMenuView';
+import {
+  blockHasType,
+  defaultProps,
+  editorHasBlockWithType,
+  type InlineContentSchema,
+  type StyleSchema,
+  type TableContent,
+} from '@blocknote/core';
 import { SideMenuExtension, SuggestionMenu } from '@blocknote/core/extensions';
+import type { DefaultReactSuggestionItem } from '@blocknote/react';
 import {
   SideMenuController,
   useBlockNoteEditor,
@@ -32,16 +49,19 @@ import {
   AlignRight,
   Check,
   ChevronRight,
-  Columns3,
   Copy,
   GripVertical,
+  Image as ImageIcon,
   IndentDecrease,
   IndentIncrease,
   Paintbrush,
+  PanelLeft,
+  PanelTop,
   Plus,
   PlusSquare,
-  Rows3,
   Scissors,
+  StretchHorizontal,
+  Table2,
   Trash2,
   type LucideIcon,
 } from 'lucide-react';
@@ -49,12 +69,18 @@ import { useState, type DragEvent, type ReactNode } from 'react';
 import styles from './style.module.less';
 
 type TextAlignment = 'left' | 'center' | 'right';
+type NoteTableContent = TableContent<InlineContentSchema, StyleSchema>;
 
 const textAlignItems: Array<{ key: TextAlignment; label: string; icon: LucideIcon }> = [
   { key: 'left', label: '左对齐', icon: AlignLeft },
   { key: 'center', label: '居中对齐', icon: AlignCenter },
   { key: 'right', label: '右对齐', icon: AlignRight },
 ];
+
+const blockHandleIconMap: Partial<Record<string, LucideIcon>> = {
+  image: ImageIcon,
+  table: Table2,
+};
 
 function isBlockEmpty(block: NoteBlock) {
   const content = (block as { content?: unknown }).content;
@@ -85,6 +111,16 @@ function getBlockProp(block: NoteBlock, prop: string) {
   return isRecord(block.props) && typeof block.props[prop] === 'string'
     ? block.props[prop]
     : undefined;
+}
+
+function getTableContent(block: NoteBlock): NoteTableContent | undefined {
+  return block.type === 'table' && isRecord((block as { content?: unknown }).content)
+    ? ((block as { content?: unknown }).content as NoteTableContent)
+    : undefined;
+}
+
+function getTableColumnCount(content: NoteTableContent) {
+  return content.columnWidths.length || content.rows[0]?.cells.length || 0;
 }
 
 async function writeClipboardData(data: { html: string; text: string }) {
@@ -136,24 +172,15 @@ function MenuItemContent({
   );
 }
 
-function BlockTypeMenuItemContent({
-  item,
-  selected,
-}: {
-  item: BlockTypeMenuItem;
-  selected?: boolean;
-}) {
-  const Icon = item.icon;
+function TableMenuSwitch({ isSelected }: { isSelected: boolean }) {
   return (
-    <>
-      <span className={styles.menuIcon}>
-        <Icon size={18} aria-hidden="true" />
-      </span>
-      <span className={styles.menuLabel}>{item.label}</span>
-      <span className={styles.menuTrailing} aria-hidden="true">
-        {selected ? <Check size={16} /> : null}
-      </span>
-    </>
+    <span
+      className={styles.switchIndicator}
+      data-selected={isSelected ? 'true' : undefined}
+      aria-hidden="true"
+    >
+      <span className={styles.switchIndicatorThumb} />
+    </span>
   );
 }
 
@@ -193,7 +220,7 @@ function QuickBlockTypes({
   );
 }
 
-function CustomSideMenu() {
+function CustomSideMenu({ plugins }: { plugins: readonly NoteEditorPlugin[] }) {
   const editor = useBlockNoteEditor(blockNoteSchema);
   const sideMenu = useExtension(SideMenuExtension, { editor });
   const suggestionMenu = useExtension(SuggestionMenu, { editor });
@@ -210,10 +237,15 @@ function CustomSideMenu() {
   }
 
   const { allItems, quickItems } = getAvailableBlockTypeItems(editor);
-  const itemMap = new Map(allItems.map((item) => [item.key, item]));
+  const slashInsertItems = sortSuggestionItemsForDisplay(
+    getNoteSlashMenuItems(editor, plugins, NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET).filter(
+      (item) => resolveSlashMenuGroup(item) !== 'AI'
+    )
+  );
   const selectedBlockType = allItems.find((item) => blockMatchesBlockTypeItem(block, item));
   const blockIsEmpty = isBlockEmpty(block);
-  const SelectedBlockIcon = selectedBlockType?.icon;
+  const isTable = block.type === 'table';
+  const SelectedBlockIcon = selectedBlockType?.icon ?? blockHandleIconMap[block.type];
   const headingLevel =
     block.type === 'heading' && isRecord(block.props) ? String(block.props.level) : undefined;
   const canUseTextColor = blockSupportsTextColor(block, editor);
@@ -224,11 +256,8 @@ function CustomSideMenu() {
   const textAlignment = canUseTextAlignment
     ? String(blockProps.textAlignment ?? defaultProps.textAlignment.default)
     : undefined;
-  const isTable = block.type === 'table';
-  const tableContent = isRecord((block as { content?: unknown }).content)
-    ? ((block as { content?: unknown }).content as Record<string, unknown>)
-    : undefined;
-  const canUseTableHeaders = isTable && editor.settings.tables.headers && tableContent;
+  const tableContent = getTableContent(block);
+  const canUseTableHeaders = Boolean(isTable && tableContent);
   const isHeaderRow = Boolean(tableContent?.headerRows);
   const isHeaderColumn = Boolean(tableContent?.headerCols);
 
@@ -257,14 +286,11 @@ function CustomSideMenu() {
     closeMenu();
   };
 
-  const insertBlockBelow = (item: BlockTypeMenuItem) => {
+  const insertSlashItemBelow = (item: DefaultReactSuggestionItem) => {
     editor.focus();
-    const insertedBlock = editor.insertBlocks(
-      [blockTypeItemToPartialBlock(item)],
-      block,
-      'after'
-    )[0];
+    const insertedBlock = editor.insertBlocks([{ type: 'paragraph' }], block, 'after')[0];
     editor.setTextCursorPosition(insertedBlock);
+    item.onItemClick();
     closeMenu();
   };
 
@@ -371,6 +397,25 @@ function CustomSideMenu() {
     closeMenu();
   };
 
+  const resetTableColumnWidths = () => {
+    if (!isTable || !tableContent) {
+      return;
+    }
+    const columnCount = getTableColumnCount(tableContent);
+    editor.updateBlock(
+      block,
+      toBlockUpdate({
+        type: 'table',
+        content: {
+          ...tableContent,
+          columnWidths: Array.from({ length: columnCount }, () => undefined),
+        },
+      })
+    );
+    closeMenu();
+    window.setTimeout(() => editor.focus());
+  };
+
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
     setDragging(true);
     sideMenu.blockDragStart(event, block);
@@ -380,6 +425,120 @@ function CustomSideMenu() {
     sideMenu.blockDragEnd();
     window.setTimeout(() => setDragging(false));
   };
+
+  const indentAlignMenu = (
+    <Dropdown.SubmenuTrigger>
+      <Dropdown.Item id="indent-align" textValue="缩进和对齐" className={styles.menuItem}>
+        <MenuItemContent
+          icon={AlignLeft}
+          label="缩进和对齐"
+          trailing={<ChevronRight size={16} />}
+        />
+      </Dropdown.Item>
+      <Dropdown.Popover className={styles.popover} placement="right top">
+        <Dropdown.Menu
+          aria-label="缩进和对齐"
+          className={styles.menu}
+          onAction={(key) => {
+            const action = String(key);
+            if (action === 'nest') {
+              nestBlock('nest');
+            }
+            if (action === 'unnest') {
+              nestBlock('unnest');
+            }
+            if (action.startsWith('align-')) {
+              setTextAlignment(action.replace('align-', '') as TextAlignment);
+            }
+          }}
+        >
+          <Dropdown.Item id="nest" textValue="增加缩进" className={styles.menuItem}>
+            <MenuItemContent icon={IndentIncrease} label="增加缩进" />
+          </Dropdown.Item>
+          <Dropdown.Item id="unnest" textValue="减少缩进" className={styles.menuItem}>
+            <MenuItemContent icon={IndentDecrease} label="减少缩进" />
+          </Dropdown.Item>
+          {canUseTextAlignment
+            ? textAlignItems.map((item) => (
+                <Dropdown.Item
+                  key={item.key}
+                  id={`align-${item.key}`}
+                  textValue={item.label}
+                  className={styles.menuItem}
+                >
+                  <MenuItemContent
+                    icon={item.icon}
+                    label={item.label}
+                    trailing={textAlignment === item.key ? <Check size={16} /> : null}
+                  />
+                </Dropdown.Item>
+              ))
+            : null}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown.SubmenuTrigger>
+  );
+
+  const colorMenu =
+    canUseColor && !isTable ? (
+      <Dropdown.SubmenuTrigger>
+        <Dropdown.Item id="colors" textValue="颜色" className={styles.menuItem}>
+          <MenuItemContent icon={Paintbrush} label="颜色" trailing={<ChevronRight size={16} />} />
+        </Dropdown.Item>
+        <Dropdown.Popover className={styles.popover} placement="right top">
+          <ColorPaletteContent
+            className={styles.colorPanel}
+            text={
+              canUseTextColor
+                ? {
+                    color: getBlockProp(block, 'textColor'),
+                    onChange: (color) => setBlockColor('textColor', color),
+                  }
+                : undefined
+            }
+            background={
+              canUseBackgroundColor
+                ? {
+                    color: getBlockProp(block, 'backgroundColor'),
+                    onChange: (color) => setBlockColor('backgroundColor', color),
+                  }
+                : undefined
+            }
+            onReset={resetBlockColor}
+          />
+        </Dropdown.Popover>
+      </Dropdown.SubmenuTrigger>
+    ) : null;
+
+  const tableIndentMenu = (
+    <Dropdown.SubmenuTrigger>
+      <Dropdown.Item id="indent" textValue="缩进" className={styles.menuItem}>
+        <MenuItemContent icon={IndentIncrease} label="缩进" trailing={<ChevronRight size={16} />} />
+      </Dropdown.Item>
+      <Dropdown.Popover className={styles.popover} placement="right top">
+        <Dropdown.Menu
+          aria-label="缩进"
+          className={styles.menu}
+          onAction={(key) => {
+            const action = String(key);
+            if (action === 'nest') {
+              nestBlock('nest');
+            }
+            if (action === 'unnest') {
+              nestBlock('unnest');
+            }
+          }}
+        >
+          <Dropdown.Item id="nest" textValue="增加缩进" className={styles.menuItem}>
+            <MenuItemContent icon={IndentIncrease} label="增加缩进" />
+          </Dropdown.Item>
+          <Dropdown.Item id="unnest" textValue="减少缩进" className={styles.menuItem}>
+            <MenuItemContent icon={IndentDecrease} label="减少缩进" />
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown.SubmenuTrigger>
+  );
 
   return (
     <div
@@ -429,12 +588,20 @@ function CustomSideMenu() {
             </Dropdown.Trigger>
             <Dropdown.Popover className={styles.popover} placement="left top" offset={8}>
               <div className={styles.menuSurface}>
-                <QuickBlockTypes block={block} items={quickItems} onSelect={applyBlockType} />
+                {!isTable ? (
+                  <QuickBlockTypes block={block} items={quickItems} onSelect={applyBlockType} />
+                ) : null}
                 <Dropdown.Menu
                   aria-label="块菜单"
                   className={styles.menu}
                   onAction={(key) => {
                     const action = String(key);
+                    if (action === 'nest') {
+                      nestBlock('nest');
+                    }
+                    if (action === 'unnest') {
+                      nestBlock('unnest');
+                    }
                     if (action === 'copy') {
                       void copyOrCutBlock('copy');
                     }
@@ -450,123 +617,13 @@ function CustomSideMenu() {
                     if (action === 'table-header-column') {
                       toggleTableHeader('column');
                     }
+                    if (action === 'table-reset-column-widths') {
+                      resetTableColumnWidths();
+                    }
                   }}
                 >
-                  <Dropdown.SubmenuTrigger>
-                    <Dropdown.Item
-                      id="indent-align"
-                      textValue="缩进和对齐"
-                      className={styles.menuItem}
-                    >
-                      <MenuItemContent
-                        icon={AlignLeft}
-                        label="缩进和对齐"
-                        trailing={<ChevronRight size={16} />}
-                      />
-                    </Dropdown.Item>
-                    <Dropdown.Popover className={styles.popover} placement="right top">
-                      <Dropdown.Menu
-                        aria-label="缩进和对齐"
-                        className={styles.menu}
-                        onAction={(key) => {
-                          const action = String(key);
-                          if (action === 'nest') {
-                            nestBlock('nest');
-                          }
-                          if (action === 'unnest') {
-                            nestBlock('unnest');
-                          }
-                          if (action.startsWith('align-')) {
-                            setTextAlignment(action.replace('align-', '') as TextAlignment);
-                          }
-                        }}
-                      >
-                        <Dropdown.Item id="nest" textValue="增加缩进" className={styles.menuItem}>
-                          <MenuItemContent icon={IndentIncrease} label="增加缩进" />
-                        </Dropdown.Item>
-                        <Dropdown.Item id="unnest" textValue="减少缩进" className={styles.menuItem}>
-                          <MenuItemContent icon={IndentDecrease} label="减少缩进" />
-                        </Dropdown.Item>
-                        {canUseTextAlignment
-                          ? textAlignItems.map((item) => (
-                              <Dropdown.Item
-                                key={item.key}
-                                id={`align-${item.key}`}
-                                textValue={item.label}
-                                className={styles.menuItem}
-                              >
-                                <MenuItemContent
-                                  icon={item.icon}
-                                  label={item.label}
-                                  trailing={textAlignment === item.key ? <Check size={16} /> : null}
-                                />
-                              </Dropdown.Item>
-                            ))
-                          : null}
-                      </Dropdown.Menu>
-                    </Dropdown.Popover>
-                  </Dropdown.SubmenuTrigger>
-
-                  {canUseColor ? (
-                    <Dropdown.SubmenuTrigger>
-                      <Dropdown.Item id="colors" textValue="颜色" className={styles.menuItem}>
-                        <MenuItemContent
-                          icon={Paintbrush}
-                          label="颜色"
-                          trailing={<ChevronRight size={16} />}
-                        />
-                      </Dropdown.Item>
-                      <Dropdown.Popover className={styles.popover} placement="right top">
-                        <ColorPaletteContent
-                          className={styles.colorPanel}
-                          text={
-                            canUseTextColor
-                              ? {
-                                  color: getBlockProp(block, 'textColor'),
-                                  onChange: (color) => setBlockColor('textColor', color),
-                                }
-                              : undefined
-                          }
-                          background={
-                            canUseBackgroundColor
-                              ? {
-                                  color: getBlockProp(block, 'backgroundColor'),
-                                  onChange: (color) => setBlockColor('backgroundColor', color),
-                                }
-                              : undefined
-                          }
-                          onReset={resetBlockColor}
-                        />
-                      </Dropdown.Popover>
-                    </Dropdown.SubmenuTrigger>
-                  ) : null}
-
-                  {canUseTableHeaders ? (
-                    <Dropdown.Section>
-                      <Dropdown.Item
-                        id="table-header-row"
-                        textValue="首行表头"
-                        className={styles.menuItem}
-                      >
-                        <MenuItemContent
-                          icon={Rows3}
-                          label="首行表头"
-                          trailing={isHeaderRow ? <Check size={16} /> : null}
-                        />
-                      </Dropdown.Item>
-                      <Dropdown.Item
-                        id="table-header-column"
-                        textValue="首列表头"
-                        className={styles.menuItem}
-                      >
-                        <MenuItemContent
-                          icon={Columns3}
-                          label="首列表头"
-                          trailing={isHeaderColumn ? <Check size={16} /> : null}
-                        />
-                      </Dropdown.Item>
-                    </Dropdown.Section>
-                  ) : null}
+                  {isTable ? tableIndentMenu : indentAlignMenu}
+                  {!isTable ? colorMenu : null}
 
                   <Dropdown.Section>
                     <Dropdown.Item id="cut" textValue="剪切" className={styles.menuItem}>
@@ -579,6 +636,44 @@ function CustomSideMenu() {
                       <MenuItemContent icon={Trash2} label="删除" />
                     </Dropdown.Item>
                   </Dropdown.Section>
+
+                  {isTable ? (
+                    <Dropdown.Section>
+                      {canUseTableHeaders ? (
+                        <>
+                          <Dropdown.Item
+                            id="table-header-row"
+                            textValue="标题行"
+                            className={styles.menuItem}
+                          >
+                            <MenuItemContent
+                              icon={PanelTop}
+                              label="标题行"
+                              trailing={<TableMenuSwitch isSelected={isHeaderRow} />}
+                            />
+                          </Dropdown.Item>
+                          <Dropdown.Item
+                            id="table-header-column"
+                            textValue="标题列"
+                            className={styles.menuItem}
+                          >
+                            <MenuItemContent
+                              icon={PanelLeft}
+                              label="标题列"
+                              trailing={<TableMenuSwitch isSelected={isHeaderColumn} />}
+                            />
+                          </Dropdown.Item>
+                        </>
+                      ) : null}
+                      <Dropdown.Item
+                        id="table-reset-column-widths"
+                        textValue="均分列宽"
+                        className={styles.menuItem}
+                      >
+                        <MenuItemContent icon={StretchHorizontal} label="均分列宽" />
+                      </Dropdown.Item>
+                    </Dropdown.Section>
+                  ) : null}
 
                   <Dropdown.Section>
                     <Dropdown.SubmenuTrigger>
@@ -598,25 +693,18 @@ function CustomSideMenu() {
                           aria-label="在下方添加"
                           className={styles.menu}
                           onAction={(key) => {
-                            const item = itemMap.get(String(key));
+                            const item = slashInsertItems.find(
+                              (_candidate, index) => `insert-slash-item-${index}` === String(key)
+                            );
                             if (item) {
-                              insertBlockBelow(item);
+                              insertSlashItemBelow(item);
                             }
                           }}
                         >
-                          {allItems.map((item) => (
-                            <Dropdown.Item
-                              key={item.key}
-                              id={item.key}
-                              textValue={item.label}
-                              className={styles.menuItem}
-                            >
-                              <BlockTypeMenuItemContent
-                                item={item}
-                                selected={selectedBlockType?.key === item.key}
-                              />
-                            </Dropdown.Item>
-                          ))}
+                          <SlashMenuDropdownItems
+                            items={slashInsertItems}
+                            getItemId={(_item, index) => `insert-slash-item-${index}`}
+                          />
                         </Dropdown.Menu>
                       </Dropdown.Popover>
                     </Dropdown.SubmenuTrigger>
@@ -631,7 +719,7 @@ function CustomSideMenu() {
   );
 }
 
-export default function NoteSideMenu() {
+export default function NoteSideMenu({ plugins }: { plugins: readonly NoteEditorPlugin[] }) {
   const readOnly = useNoteEditorReadOnlyContext();
 
   if (readOnly) {
@@ -640,7 +728,7 @@ export default function NoteSideMenu() {
 
   return (
     <SideMenuController
-      sideMenu={CustomSideMenu}
+      sideMenu={() => <CustomSideMenu plugins={plugins} />}
       floatingUIOptions={{
         useFloatingOptions: {
           placement: 'left-start',

--- a/src/components/Note/NoteSideMenu/index.tsx
+++ b/src/components/Note/NoteSideMenu/index.tsx
@@ -1,0 +1,651 @@
+import type { CustomBlockNoteEditor } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
+import {
+  applyBlockTypeToBlocks,
+  blockMatchesBlockTypeItem,
+  blockTypeItemToPartialBlock,
+  getAvailableBlockTypeItems,
+  type BlockTypeMenuItem,
+} from '@/components/Note/NoteEditorMenus/blockTypes';
+import { ColorPaletteContent } from '@/components/Note/NoteEditorMenus/colorPalette';
+import type { ColorKey } from '@/components/Note/NoteEditorMenus/colorPaletteData';
+import {
+  isRecord,
+  toBlockUpdate,
+  type NoteBlock,
+  type NotePartialBlock,
+} from '@/components/Note/NoteEditorMenus/utils';
+import { blockHasType, defaultProps, editorHasBlockWithType } from '@blocknote/core';
+import { SideMenuExtension, SuggestionMenu } from '@blocknote/core/extensions';
+import {
+  SideMenuController,
+  useBlockNoteEditor,
+  useExtension,
+  useExtensionState,
+} from '@blocknote/react';
+import { Button, Dropdown } from '@heroui/react';
+import clsx from 'clsx';
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  Check,
+  ChevronRight,
+  Columns3,
+  Copy,
+  GripVertical,
+  IndentDecrease,
+  IndentIncrease,
+  Paintbrush,
+  Plus,
+  PlusSquare,
+  Rows3,
+  Scissors,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
+import { useState, type DragEvent, type ReactNode } from 'react';
+import styles from './style.module.less';
+
+type TextAlignment = 'left' | 'center' | 'right';
+
+const textAlignItems: Array<{ key: TextAlignment; label: string; icon: LucideIcon }> = [
+  { key: 'left', label: '左对齐', icon: AlignLeft },
+  { key: 'center', label: '居中对齐', icon: AlignCenter },
+  { key: 'right', label: '右对齐', icon: AlignRight },
+];
+
+function isBlockEmpty(block: NoteBlock) {
+  const content = (block as { content?: unknown }).content;
+  return Array.isArray(content) && content.length === 0;
+}
+
+function blockSupportsTextColor(block: NoteBlock, editor: CustomBlockNoteEditor) {
+  return (
+    blockHasType(block, editor, block.type, { textColor: 'string' }) &&
+    editorHasBlockWithType(editor, block.type, { textColor: 'string' })
+  );
+}
+
+function blockSupportsBackgroundColor(block: NoteBlock, editor: CustomBlockNoteEditor) {
+  return (
+    blockHasType(block, editor, block.type, { backgroundColor: 'string' }) &&
+    editorHasBlockWithType(editor, block.type, { backgroundColor: 'string' })
+  );
+}
+
+function blockSupportsTextAlignment(block: NoteBlock, editor: CustomBlockNoteEditor) {
+  return blockHasType(block, editor, block.type, {
+    textAlignment: defaultProps.textAlignment,
+  });
+}
+
+function getBlockProp(block: NoteBlock, prop: string) {
+  return isRecord(block.props) && typeof block.props[prop] === 'string'
+    ? block.props[prop]
+    : undefined;
+}
+
+async function writeClipboardData(data: { html: string; text: string }) {
+  if (navigator.clipboard?.write && 'ClipboardItem' in window) {
+    try {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          'text/html': new Blob([data.html], { type: 'text/html' }),
+          'text/plain': new Blob([data.text], { type: 'text/plain' }),
+        }),
+      ]);
+      return true;
+    } catch {
+      // Fall through to plain text or the legacy copy command.
+    }
+  }
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(data.text);
+      return true;
+    } catch {
+      // Fall through to the legacy copy command.
+    }
+  }
+
+  return document.execCommand('copy');
+}
+
+function MenuItemContent({
+  icon: Icon,
+  label,
+  trailing,
+}: {
+  icon: LucideIcon;
+  label: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <>
+      <span className={styles.menuIcon}>
+        <Icon size={18} aria-hidden="true" />
+      </span>
+      <span className={styles.menuLabel}>{label}</span>
+      <span className={styles.menuTrailing} aria-hidden="true">
+        {trailing}
+      </span>
+    </>
+  );
+}
+
+function BlockTypeMenuItemContent({
+  item,
+  selected,
+}: {
+  item: BlockTypeMenuItem;
+  selected?: boolean;
+}) {
+  const Icon = item.icon;
+  return (
+    <>
+      <span className={styles.menuIcon}>
+        <Icon size={18} aria-hidden="true" />
+      </span>
+      <span className={styles.menuLabel}>{item.label}</span>
+      <span className={styles.menuTrailing} aria-hidden="true">
+        {selected ? <Check size={16} /> : null}
+      </span>
+    </>
+  );
+}
+
+function QuickBlockTypes({
+  block,
+  items,
+  onSelect,
+}: {
+  block: NoteBlock;
+  items: BlockTypeMenuItem[];
+  onSelect: (item: BlockTypeMenuItem) => void;
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.quickTypes} role="group" aria-label="块类型">
+      {items.map((item) => {
+        const Icon = item.icon;
+        const selected = blockMatchesBlockTypeItem(block, item);
+        return (
+          <Button
+            key={item.key}
+            variant="ghost"
+            size="sm"
+            isIconOnly
+            className={clsx(styles.quickTypeButton, selected && styles.quickTypeButtonActive)}
+            aria-label={item.label}
+            onPress={() => onSelect(item)}
+          >
+            <Icon size={18} aria-hidden="true" />
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+function CustomSideMenu() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const sideMenu = useExtension(SideMenuExtension, { editor });
+  const suggestionMenu = useExtension(SuggestionMenu, { editor });
+  const extensionBlock = useExtensionState(SideMenuExtension, {
+    editor,
+    selector: (state) => state?.block,
+  });
+  const [open, setOpen] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const block = extensionBlock as NoteBlock | undefined;
+
+  if (!block || !editor.isEditable) {
+    return null;
+  }
+
+  const { allItems, quickItems } = getAvailableBlockTypeItems(editor);
+  const itemMap = new Map(allItems.map((item) => [item.key, item]));
+  const selectedBlockType = allItems.find((item) => blockMatchesBlockTypeItem(block, item));
+  const blockIsEmpty = isBlockEmpty(block);
+  const SelectedBlockIcon = selectedBlockType?.icon;
+  const headingLevel =
+    block.type === 'heading' && isRecord(block.props) ? String(block.props.level) : undefined;
+  const canUseTextColor = blockSupportsTextColor(block, editor);
+  const canUseBackgroundColor = blockSupportsBackgroundColor(block, editor);
+  const canUseColor = canUseTextColor || canUseBackgroundColor;
+  const canUseTextAlignment = blockSupportsTextAlignment(block, editor);
+  const blockProps = isRecord(block.props) ? block.props : {};
+  const textAlignment = canUseTextAlignment
+    ? String(blockProps.textAlignment ?? defaultProps.textAlignment.default)
+    : undefined;
+  const isTable = block.type === 'table';
+  const tableContent = isRecord((block as { content?: unknown }).content)
+    ? ((block as { content?: unknown }).content as Record<string, unknown>)
+    : undefined;
+  const canUseTableHeaders = isTable && editor.settings.tables.headers && tableContent;
+  const isHeaderRow = Boolean(tableContent?.headerRows);
+  const isHeaderColumn = Boolean(tableContent?.headerCols);
+
+  const closeMenu = () => {
+    setOpen(false);
+    sideMenu.unfreezeMenu();
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      sideMenu.freezeMenu();
+    } else {
+      sideMenu.unfreezeMenu();
+    }
+  };
+
+  const focusBlock = () => {
+    editor.setTextCursorPosition(block);
+    editor.focus();
+  };
+
+  const applyBlockType = (item: BlockTypeMenuItem) => {
+    editor.focus();
+    applyBlockTypeToBlocks(editor, [block], item);
+    closeMenu();
+  };
+
+  const insertBlockBelow = (item: BlockTypeMenuItem) => {
+    editor.focus();
+    const insertedBlock = editor.insertBlocks(
+      [blockTypeItemToPartialBlock(item)],
+      block,
+      'after'
+    )[0];
+    editor.setTextCursorPosition(insertedBlock);
+    closeMenu();
+  };
+
+  const openSlashBelow = () => {
+    if (isBlockEmpty(block)) {
+      editor.setTextCursorPosition(block);
+      suggestionMenu.openSuggestionMenu('/');
+      closeMenu();
+      return;
+    }
+
+    const insertedBlock = editor.insertBlocks([{ type: 'paragraph' }], block, 'after')[0];
+    editor.setTextCursorPosition(insertedBlock);
+    suggestionMenu.openSuggestionMenu('/');
+    closeMenu();
+  };
+
+  const setTextAlignment = (alignment: TextAlignment) => {
+    if (!canUseTextAlignment) {
+      return;
+    }
+    editor.updateBlock(block, toBlockUpdate({ props: { textAlignment: alignment } }));
+    closeMenu();
+  };
+
+  const nestBlock = (type: 'nest' | 'unnest') => {
+    focusBlock();
+    if (type === 'nest' && editor.canNestBlock()) {
+      editor.nestBlock();
+    }
+    if (type === 'unnest' && editor.canUnnestBlock()) {
+      editor.unnestBlock();
+    }
+    closeMenu();
+  };
+
+  const setBlockColor = (target: 'textColor' | 'backgroundColor', color: ColorKey) => {
+    editor.updateBlock(
+      block,
+      toBlockUpdate({
+        props: { [target]: color },
+      })
+    );
+    closeMenu();
+    window.setTimeout(() => editor.focus());
+  };
+
+  const resetBlockColor = () => {
+    editor.updateBlock(
+      block,
+      toBlockUpdate({
+        props: {
+          ...(canUseTextColor ? { textColor: 'default' } : {}),
+          ...(canUseBackgroundColor ? { backgroundColor: 'default' } : {}),
+        },
+      })
+    );
+    closeMenu();
+    window.setTimeout(() => editor.focus());
+  };
+
+  const deleteBlock = () => {
+    const nextFocusBlock = editor.getNextBlock(block) ?? editor.getPrevBlock(block);
+    editor.removeBlocks([block]);
+    if (nextFocusBlock) {
+      editor.setTextCursorPosition(nextFocusBlock);
+    }
+    closeMenu();
+    editor.focus();
+  };
+
+  const copyOrCutBlock = async (mode: 'copy' | 'cut') => {
+    const blocks = [block as unknown as NotePartialBlock];
+    const clipboardData = {
+      html: editor.blocksToFullHTML(blocks),
+      text: editor.blocksToMarkdownLossy(blocks),
+    };
+
+    const copied = await writeClipboardData(clipboardData);
+    if (copied && mode === 'cut') {
+      deleteBlock();
+      return;
+    }
+
+    closeMenu();
+  };
+
+  const toggleTableHeader = (target: 'row' | 'column') => {
+    if (!canUseTableHeaders || !tableContent) {
+      return;
+    }
+    editor.updateBlock(
+      block,
+      toBlockUpdate({
+        type: 'table',
+        content: {
+          ...tableContent,
+          ...(target === 'row'
+            ? { headerRows: isHeaderRow ? undefined : 1 }
+            : { headerCols: isHeaderColumn ? undefined : 1 }),
+        },
+      })
+    );
+    closeMenu();
+  };
+
+  const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    setDragging(true);
+    sideMenu.blockDragStart(event, block);
+  };
+
+  const handleDragEnd = () => {
+    sideMenu.blockDragEnd();
+    window.setTimeout(() => setDragging(false));
+  };
+
+  return (
+    <div
+      className={clsx('bn-side-menu', styles.sideMenu)}
+      data-block-type={block.type}
+      data-level={headingLevel}
+    >
+      {blockIsEmpty ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          className={styles.sideMenuButton}
+          aria-label="添加块"
+          onPress={openSlashBelow}
+        >
+          <Plus size={18} aria-hidden="true" />
+        </Button>
+      ) : null}
+      {!blockIsEmpty ? (
+        <div className={styles.dragHandleWrapper}>
+          <button
+            type="button"
+            className={clsx(styles.sideMenuButton, styles.dragHandleButton)}
+            draggable="true"
+            aria-label="块菜单"
+            onClick={() => {
+              if (!dragging) {
+                handleOpenChange(!open);
+              }
+            }}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            {SelectedBlockIcon ? (
+              <SelectedBlockIcon
+                size={16}
+                className={styles.dragHandleTypeIcon}
+                aria-hidden="true"
+              />
+            ) : null}
+            <GripVertical size={16} aria-hidden="true" />
+          </button>
+          <Dropdown isOpen={open} onOpenChange={handleOpenChange}>
+            <Dropdown.Trigger className={styles.dropdownAnchor} isDisabled aria-hidden="true">
+              <span />
+            </Dropdown.Trigger>
+            <Dropdown.Popover className={styles.popover} placement="left top" offset={8}>
+              <div className={styles.menuSurface}>
+                <QuickBlockTypes block={block} items={quickItems} onSelect={applyBlockType} />
+                <Dropdown.Menu
+                  aria-label="块菜单"
+                  className={styles.menu}
+                  onAction={(key) => {
+                    const action = String(key);
+                    if (action === 'copy') {
+                      void copyOrCutBlock('copy');
+                    }
+                    if (action === 'cut') {
+                      void copyOrCutBlock('cut');
+                    }
+                    if (action === 'delete') {
+                      deleteBlock();
+                    }
+                    if (action === 'table-header-row') {
+                      toggleTableHeader('row');
+                    }
+                    if (action === 'table-header-column') {
+                      toggleTableHeader('column');
+                    }
+                  }}
+                >
+                  <Dropdown.SubmenuTrigger>
+                    <Dropdown.Item
+                      id="indent-align"
+                      textValue="缩进和对齐"
+                      className={styles.menuItem}
+                    >
+                      <MenuItemContent
+                        icon={AlignLeft}
+                        label="缩进和对齐"
+                        trailing={<ChevronRight size={16} />}
+                      />
+                    </Dropdown.Item>
+                    <Dropdown.Popover className={styles.popover} placement="right top">
+                      <Dropdown.Menu
+                        aria-label="缩进和对齐"
+                        className={styles.menu}
+                        onAction={(key) => {
+                          const action = String(key);
+                          if (action === 'nest') {
+                            nestBlock('nest');
+                          }
+                          if (action === 'unnest') {
+                            nestBlock('unnest');
+                          }
+                          if (action.startsWith('align-')) {
+                            setTextAlignment(action.replace('align-', '') as TextAlignment);
+                          }
+                        }}
+                      >
+                        <Dropdown.Item id="nest" textValue="增加缩进" className={styles.menuItem}>
+                          <MenuItemContent icon={IndentIncrease} label="增加缩进" />
+                        </Dropdown.Item>
+                        <Dropdown.Item id="unnest" textValue="减少缩进" className={styles.menuItem}>
+                          <MenuItemContent icon={IndentDecrease} label="减少缩进" />
+                        </Dropdown.Item>
+                        {canUseTextAlignment
+                          ? textAlignItems.map((item) => (
+                              <Dropdown.Item
+                                key={item.key}
+                                id={`align-${item.key}`}
+                                textValue={item.label}
+                                className={styles.menuItem}
+                              >
+                                <MenuItemContent
+                                  icon={item.icon}
+                                  label={item.label}
+                                  trailing={textAlignment === item.key ? <Check size={16} /> : null}
+                                />
+                              </Dropdown.Item>
+                            ))
+                          : null}
+                      </Dropdown.Menu>
+                    </Dropdown.Popover>
+                  </Dropdown.SubmenuTrigger>
+
+                  {canUseColor ? (
+                    <Dropdown.SubmenuTrigger>
+                      <Dropdown.Item id="colors" textValue="颜色" className={styles.menuItem}>
+                        <MenuItemContent
+                          icon={Paintbrush}
+                          label="颜色"
+                          trailing={<ChevronRight size={16} />}
+                        />
+                      </Dropdown.Item>
+                      <Dropdown.Popover className={styles.popover} placement="right top">
+                        <ColorPaletteContent
+                          className={styles.colorPanel}
+                          text={
+                            canUseTextColor
+                              ? {
+                                  color: getBlockProp(block, 'textColor'),
+                                  onChange: (color) => setBlockColor('textColor', color),
+                                }
+                              : undefined
+                          }
+                          background={
+                            canUseBackgroundColor
+                              ? {
+                                  color: getBlockProp(block, 'backgroundColor'),
+                                  onChange: (color) => setBlockColor('backgroundColor', color),
+                                }
+                              : undefined
+                          }
+                          onReset={resetBlockColor}
+                        />
+                      </Dropdown.Popover>
+                    </Dropdown.SubmenuTrigger>
+                  ) : null}
+
+                  {canUseTableHeaders ? (
+                    <Dropdown.Section>
+                      <Dropdown.Item
+                        id="table-header-row"
+                        textValue="首行表头"
+                        className={styles.menuItem}
+                      >
+                        <MenuItemContent
+                          icon={Rows3}
+                          label="首行表头"
+                          trailing={isHeaderRow ? <Check size={16} /> : null}
+                        />
+                      </Dropdown.Item>
+                      <Dropdown.Item
+                        id="table-header-column"
+                        textValue="首列表头"
+                        className={styles.menuItem}
+                      >
+                        <MenuItemContent
+                          icon={Columns3}
+                          label="首列表头"
+                          trailing={isHeaderColumn ? <Check size={16} /> : null}
+                        />
+                      </Dropdown.Item>
+                    </Dropdown.Section>
+                  ) : null}
+
+                  <Dropdown.Section>
+                    <Dropdown.Item id="cut" textValue="剪切" className={styles.menuItem}>
+                      <MenuItemContent icon={Scissors} label="剪切" />
+                    </Dropdown.Item>
+                    <Dropdown.Item id="copy" textValue="复制" className={styles.menuItem}>
+                      <MenuItemContent icon={Copy} label="复制" />
+                    </Dropdown.Item>
+                    <Dropdown.Item id="delete" textValue="删除" className={styles.menuItem}>
+                      <MenuItemContent icon={Trash2} label="删除" />
+                    </Dropdown.Item>
+                  </Dropdown.Section>
+
+                  <Dropdown.Section>
+                    <Dropdown.SubmenuTrigger>
+                      <Dropdown.Item
+                        id="insert-below"
+                        textValue="在下方添加"
+                        className={styles.menuItem}
+                      >
+                        <MenuItemContent
+                          icon={PlusSquare}
+                          label="在下方添加"
+                          trailing={<ChevronRight size={16} />}
+                        />
+                      </Dropdown.Item>
+                      <Dropdown.Popover className={styles.popover} placement="right top">
+                        <Dropdown.Menu
+                          aria-label="在下方添加"
+                          className={styles.menu}
+                          onAction={(key) => {
+                            const item = itemMap.get(String(key));
+                            if (item) {
+                              insertBlockBelow(item);
+                            }
+                          }}
+                        >
+                          {allItems.map((item) => (
+                            <Dropdown.Item
+                              key={item.key}
+                              id={item.key}
+                              textValue={item.label}
+                              className={styles.menuItem}
+                            >
+                              <BlockTypeMenuItemContent
+                                item={item}
+                                selected={selectedBlockType?.key === item.key}
+                              />
+                            </Dropdown.Item>
+                          ))}
+                        </Dropdown.Menu>
+                      </Dropdown.Popover>
+                    </Dropdown.SubmenuTrigger>
+                  </Dropdown.Section>
+                </Dropdown.Menu>
+              </div>
+            </Dropdown.Popover>
+          </Dropdown>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function NoteSideMenu() {
+  const readOnly = useNoteEditorReadOnlyContext();
+
+  if (readOnly) {
+    return null;
+  }
+
+  return (
+    <SideMenuController
+      sideMenu={CustomSideMenu}
+      floatingUIOptions={{
+        useFloatingOptions: {
+          placement: 'left-start',
+        },
+      }}
+    />
+  );
+}

--- a/src/components/Note/NoteSideMenu/style.module.less
+++ b/src/components/Note/NoteSideMenu/style.module.less
@@ -150,6 +150,29 @@
   color: var(--primary);
 }
 
+.switchIndicator {
+  width: calc(var(--control-height-sm) + var(--space-xs));
+  height: var(--space-md);
+  display: inline-flex;
+  align-items: center;
+  padding: calc(var(--space-2xs) / 2);
+  border-radius: var(--radius-xl);
+  background: var(--surface-tertiary);
+}
+
+.switchIndicatorThumb {
+  width: calc(var(--space-sm) + var(--space-2xs) / 2);
+  height: calc(var(--space-sm) + var(--space-2xs) / 2);
+  border-radius: var(--radius-xl);
+  background: var(--overlay);
+  box-shadow: var(--surface-shadow);
+}
+
+.switchIndicator[data-selected='true'] {
+  justify-content: flex-end;
+  background: var(--primary);
+}
+
 .colorPanel {
   padding: var(--space-sm);
 }

--- a/src/components/Note/NoteSideMenu/style.module.less
+++ b/src/components/Note/NoteSideMenu/style.module.less
@@ -1,0 +1,155 @@
+.sideMenu {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  background: transparent;
+  overflow: visible;
+  transform: translateX(calc(-1 * var(--space-xs)));
+}
+
+.sideMenuButton {
+  width: var(--control-height-sm);
+  min-width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.sideMenuButton:hover,
+.sideMenuButton[data-hovered],
+.sideMenuButton[data-pressed],
+.sideMenuButton[data-focus-visible] {
+  background: var(--surface-secondary);
+  color: var(--surface-secondary-foreground);
+}
+
+.dragHandleWrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.dragHandleButton {
+  width: auto;
+  min-width: auto;
+  gap: var(--space-2xs);
+  padding-inline: var(--space-2xs);
+  border: 1px solid var(--border-light);
+  background: var(--overlay);
+  cursor: grab;
+}
+
+.dragHandleButton:active {
+  cursor: grabbing;
+}
+
+.dragHandleTypeIcon {
+  color: var(--primary);
+}
+
+.dropdownAnchor {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.popover {
+  padding: 0;
+}
+
+.menuSurface {
+  --note-side-menu-width: 14rem;
+
+  width: var(--note-side-menu-width);
+  max-width: calc(100vw - var(--space-xl));
+}
+
+.quickTypes {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  gap: var(--space-2xs);
+  padding: var(--space-xs);
+}
+
+.quickTypeButton {
+  flex: 0 0 var(--control-height-sm);
+  width: var(--control-height-sm);
+  min-width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  padding: 0;
+  color: var(--overlay-foreground);
+}
+
+.quickTypeButtonActive {
+  background: var(--accent-soft);
+  color: var(--accent-soft-foreground);
+}
+
+.menu {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  gap: var(--space-2xs);
+  padding: var(--space-xs);
+}
+
+.menuItem {
+  width: 100%;
+  min-height: var(--control-height);
+  display: grid;
+  grid-template-columns: var(--control-height-sm) minmax(0, 1fr) var(--control-height-sm);
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 0 var(--space-xs);
+  color: var(--overlay-foreground);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.menuItem:hover,
+.menuItem[data-hovered],
+.menuItem[data-focused],
+.menuItem[data-open] {
+  background: var(--surface-secondary);
+}
+
+.menuIcon,
+.menuTrailing {
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+.menuLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.menuTrailing {
+  justify-self: end;
+  color: var(--primary);
+}
+
+.colorPanel {
+  padding: var(--space-sm);
+}

--- a/src/components/Note/NoteSlashMenu/buildSlashMenuItems.ts
+++ b/src/components/Note/NoteSlashMenu/buildSlashMenuItems.ts
@@ -9,6 +9,20 @@ import type { NoteEditorPlugin, PluginEditor } from '../CustomBlockNote/plugins/
  */
 type SlashMenuItemWithKey = DefaultReactSuggestionItem & { key?: string };
 
+/**
+ * BlockNote 在 `getDefaultReactSlashMenuItems` 里为每个默认项设置了稳定字段 `key`，
+ * 与字典 `slash_menu.*` 及图标映射一致；此处声明要从 / 菜单中移除的默认项。
+ *
+ * 当前移除：
+ * - `file` → 通用文档/附件
+ * - `audio`、`video` → 媒体块
+ */
+export const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS = ['file', 'audio', 'video'] as const;
+
+export const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET = new Set<string>(
+  NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS
+);
+
 export function getSlashMenuItemKey(item: DefaultReactSuggestionItem): string | undefined {
   const key = (item as SlashMenuItemWithKey).key;
   return typeof key === 'string' ? key : undefined;
@@ -39,4 +53,15 @@ export function collectPluginSlashMenuItems(
   // 因此具体 schema 的 editor 不能直接赋值给宽类型 PluginEditor，这里在边界处做一次断言。
   const pluginEditor = editor as unknown as PluginEditor;
   return plugins.flatMap((plugin) => plugin.slashMenu?.({ editor: pluginEditor }) ?? []);
+}
+
+export function getNoteSlashMenuItems(
+  editor: CustomBlockNoteEditor,
+  plugins: readonly NoteEditorPlugin[],
+  hiddenDefaultKeys: ReadonlySet<string> | readonly string[]
+): DefaultReactSuggestionItem[] {
+  return [
+    ...getFilteredDefaultReactSlashMenuItems(editor, hiddenDefaultKeys),
+    ...collectPluginSlashMenuItems(plugins, editor),
+  ];
 }

--- a/src/components/Note/NoteSlashMenu/buildSlashMenuItems.ts
+++ b/src/components/Note/NoteSlashMenu/buildSlashMenuItems.ts
@@ -9,7 +9,7 @@ import type { NoteEditorPlugin, PluginEditor } from '../CustomBlockNote/plugins/
  */
 type SlashMenuItemWithKey = DefaultReactSuggestionItem & { key?: string };
 
-function getSlashMenuItemKey(item: DefaultReactSuggestionItem): string | undefined {
+export function getSlashMenuItemKey(item: DefaultReactSuggestionItem): string | undefined {
   const key = (item as SlashMenuItemWithKey).key;
   return typeof key === 'string' ? key : undefined;
 }

--- a/src/components/Note/NoteSlashMenu/index.tsx
+++ b/src/components/Note/NoteSlashMenu/index.tsx
@@ -2,258 +2,15 @@ import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import type { DefaultReactSuggestionItem, SuggestionMenuProps } from '@blocknote/react';
 import { SuggestionMenuController } from '@blocknote/react';
-import { Header, ListBox, ListBoxItem, ListBoxSection } from '@heroui/react';
-import clsx from 'clsx';
+import { ListBox, ListBoxItem } from '@heroui/react';
 import {
-  Braces,
-  CheckSquare,
-  Heading1,
-  Heading2,
-  Heading3,
-  Heading4,
-  Heading5,
-  Heading6,
-  Image,
-  Link as LinkIcon,
-  List,
-  ListOrdered,
-  ListTree,
-  Minus,
-  Smile,
-  Table,
-  TextQuote,
-  Type,
-} from 'lucide-react';
-import { createElement } from 'react';
-import {
-  collectPluginSlashMenuItems,
-  getFilteredDefaultReactSlashMenuItems,
-  getSlashMenuItemKey,
+  NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET,
+  getNoteSlashMenuItems,
 } from './buildSlashMenuItems';
 import type { NoteSlashMenuProps } from './index.type';
+import { sortSuggestionItemsForDisplay } from './slashMenuModel';
+import { SlashMenuListBoxItems } from './slashMenuView';
 import styles from './style.module.less';
-
-/**
- * BlockNote 在 `getDefaultReactSlashMenuItems` 里为每个默认项设置了稳定字段 `key`，
- * 与字典 `slash_menu.*` 及图标映射一致；此处声明要从 / 菜单中移除的默认项。
- *
- * 当前移除：
- * - `file` → 通用文档/附件
- * - `audio`、`video` → 媒体块
- */
-const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS = ['file', 'audio', 'video'] as const;
-
-const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET = new Set<string>(
-  NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS
-);
-
-const SLASH_MENU_GROUP_ORDER = ['基础', '常用', '高级', 'AI', '其他'] as const;
-
-const SLASH_MENU_GROUP_LABEL_MAP: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
-  标题: '基础',
-  基础: '基础',
-  基本块: '基础',
-  基础区块: '基础',
-  高级功能: '常用',
-  媒体: '常用',
-  高级: '高级',
-  AI: 'AI',
-  其他: '其他',
-};
-
-const SLASH_MENU_GROUP_BY_KEY: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
-  paragraph: '基础',
-  heading: '基础',
-  heading_2: '基础',
-  heading_3: '基础',
-  heading_4: '基础',
-  heading_5: '基础',
-  heading_6: '基础',
-  numbered_list: '基础',
-  bullet_list: '基础',
-  check_list: '常用',
-  code_block: '基础',
-  quote: '基础',
-  divider: '基础',
-  link: '基础',
-  image: '常用',
-  table: '常用',
-  toggle_list: '常用',
-  toggle_heading: '常用',
-  toggle_heading_2: '常用',
-  toggle_heading_3: '常用',
-  emoji: '常用',
-};
-
-const SLASH_MENU_TITLE_BY_KEY: Record<string, string> = {
-  paragraph: '文本',
-  heading: '一级标题',
-  heading_2: '二级标题',
-  heading_3: '三级标题',
-  heading_4: '四级标题',
-  heading_5: '五级标题',
-  heading_6: '六级标题',
-  numbered_list: '有序列表',
-  bullet_list: '无序列表',
-  check_list: '任务',
-  code_block: '代码块',
-  quote: '引用',
-  divider: '分隔线',
-  link: '链接',
-  image: '图片',
-  table: '表格',
-  toggle_list: '折叠列表',
-  toggle_heading: '可折叠一级标题',
-  toggle_heading_2: '可折叠二级标题',
-  toggle_heading_3: '可折叠三级标题',
-  emoji: 'Emoji',
-};
-
-const SLASH_MENU_ITEM_ORDER = [
-  'paragraph',
-  'heading',
-  'heading_2',
-  'heading_3',
-  'heading_4',
-  'heading_5',
-  'heading_6',
-  'numbered_list',
-  'bullet_list',
-  'check_list',
-  'code_block',
-  'quote',
-  'divider',
-  'link',
-  'image',
-  'table',
-  'toggle_list',
-  'toggle_heading',
-  'toggle_heading_2',
-  'toggle_heading_3',
-  'emoji',
-] as const;
-
-const SLASH_MENU_ICON_MAP: Record<string, typeof Type> = {
-  paragraph: Type,
-  heading: Heading1,
-  heading_2: Heading2,
-  heading_3: Heading3,
-  heading_4: Heading4,
-  heading_5: Heading5,
-  heading_6: Heading6,
-  toggle_heading: Heading1,
-  toggle_heading_2: Heading2,
-  toggle_heading_3: Heading3,
-  quote: TextQuote,
-  toggle_list: ListTree,
-  numbered_list: ListOrdered,
-  bullet_list: List,
-  check_list: CheckSquare,
-  code_block: Braces,
-  divider: Minus,
-  link: LinkIcon,
-  table: Table,
-  image: Image,
-  emoji: Smile,
-};
-
-const SLASH_MENU_ICON_COLOR_BY_KEY: Record<string, string> = {
-  paragraph: styles.iconPrimary,
-  heading: styles.iconPrimary,
-  heading_2: styles.iconPrimary,
-  heading_3: styles.iconPrimary,
-  heading_4: styles.iconPrimary,
-  heading_5: styles.iconPrimary,
-  heading_6: styles.iconPrimary,
-  numbered_list: styles.iconAccent,
-  bullet_list: styles.iconAccent,
-  check_list: styles.iconSuccess,
-  code_block: styles.iconSuccess,
-  quote: styles.iconPrimary,
-  divider: styles.iconWarning,
-  link: styles.iconPrimary,
-  image: styles.iconWarning,
-  table: styles.iconSuccess,
-  toggle_list: styles.iconPrimary,
-  toggle_heading: styles.iconPrimary,
-  toggle_heading_2: styles.iconPrimary,
-  toggle_heading_3: styles.iconPrimary,
-  emoji: styles.iconAccent,
-};
-
-function resolveSlashMenuGroup(item: DefaultReactSuggestionItem): string {
-  const key = getSlashMenuItemKey(item);
-  if (key && SLASH_MENU_GROUP_BY_KEY[key]) {
-    return SLASH_MENU_GROUP_BY_KEY[key];
-  }
-  const rawGroup = typeof item.group === 'string' ? item.group : '';
-  return SLASH_MENU_GROUP_LABEL_MAP[rawGroup] ?? rawGroup ?? '其他';
-}
-
-function resolveSlashMenuTitle(item: DefaultReactSuggestionItem) {
-  const key = getSlashMenuItemKey(item);
-  return key ? (SLASH_MENU_TITLE_BY_KEY[key] ?? item.title) : item.title;
-}
-
-function resolveSlashMenuIconColor(item: DefaultReactSuggestionItem) {
-  const key = getSlashMenuItemKey(item);
-  if (key && SLASH_MENU_ICON_COLOR_BY_KEY[key]) {
-    return SLASH_MENU_ICON_COLOR_BY_KEY[key];
-  }
-  if (item.group === 'AI') {
-    return styles.iconAccent;
-  }
-  if (item.title === '公式') {
-    return styles.iconMuted;
-  }
-  return styles.iconPrimary;
-}
-
-function resolveSlashMenuIcon(item: DefaultReactSuggestionItem) {
-  const key = getSlashMenuItemKey(item);
-  const Icon = key ? SLASH_MENU_ICON_MAP[key] : undefined;
-  if (Icon) {
-    return createElement(Icon, { size: 18, strokeWidth: 2 });
-  }
-  return item.icon ?? null;
-}
-
-function compareSlashMenuItems(a: DefaultReactSuggestionItem, b: DefaultReactSuggestionItem) {
-  const aKey = getSlashMenuItemKey(a);
-  const bKey = getSlashMenuItemKey(b);
-  const aIndex = aKey
-    ? SLASH_MENU_ITEM_ORDER.indexOf(aKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
-    : -1;
-  const bIndex = bKey
-    ? SLASH_MENU_ITEM_ORDER.indexOf(bKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
-    : -1;
-  if (aIndex !== -1 || bIndex !== -1) {
-    return (
-      (aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex) -
-      (bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex)
-    );
-  }
-  return resolveSlashMenuTitle(a).localeCompare(resolveSlashMenuTitle(b), 'zh-CN');
-}
-
-function groupSuggestionItems(items: DefaultReactSuggestionItem[]) {
-  const groupMap = new Map<string, DefaultReactSuggestionItem[]>();
-  for (const item of [...items].sort(compareSlashMenuItems)) {
-    const group = resolveSlashMenuGroup(item);
-    groupMap.set(group, [...(groupMap.get(group) ?? []), item]);
-  }
-
-  return [...groupMap.entries()].sort(([a], [b]) => {
-    const aIndex = SLASH_MENU_GROUP_ORDER.indexOf(a as (typeof SLASH_MENU_GROUP_ORDER)[number]);
-    const bIndex = SLASH_MENU_GROUP_ORDER.indexOf(b as (typeof SLASH_MENU_GROUP_ORDER)[number]);
-    if (aIndex === -1 && bIndex === -1) {
-      return a.localeCompare(b, 'zh-CN');
-    }
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
-}
 
 function getSuggestionItemId(index: number) {
   return `slash-item-${index}`;
@@ -283,14 +40,12 @@ function NoteSuggestionMenu({
     return <SlashMenuState text="无匹配项" />;
   }
 
-  const groupedItems = groupSuggestionItems(items);
-  const groupStartIndexes = groupedItems.map(([, groupItems], groupIndex) =>
-    groupedItems
-      .slice(0, groupIndex)
-      .reduce((count, [, previousGroupItems]) => count + previousGroupItems.length, 0)
-  );
   const selectedItemIndex = selectedIndex ?? -1;
-  const selectedKey = selectedItemIndex >= 0 ? getSuggestionItemId(selectedItemIndex) : undefined;
+  const displayItems = sortSuggestionItemsForDisplay(items);
+  const selectedItem = selectedItemIndex >= 0 ? items[selectedItemIndex] : undefined;
+  const selectedDisplayIndex = selectedItem ? displayItems.indexOf(selectedItem) : -1;
+  const selectedKey =
+    selectedDisplayIndex >= 0 ? getSuggestionItemId(selectedDisplayIndex) : undefined;
 
   return (
     <ListBox
@@ -299,32 +54,11 @@ function NoteSuggestionMenu({
       selectedKeys={selectedKey ? [selectedKey] : []}
       className={styles.menu}
     >
-      {groupedItems.map(([group, groupItems], groupIndex) => (
-        <ListBoxSection id={`slash-group-${group}`} className={styles.section} key={group}>
-          <Header className={styles.sectionTitle}>{group}</Header>
-          {groupItems.map((item, itemIndexInGroup) => {
-            const itemIndex = groupStartIndexes[groupIndex] + itemIndexInGroup;
-            const title = resolveSlashMenuTitle(item);
-            return (
-              <ListBoxItem
-                key={getSuggestionItemId(itemIndex)}
-                id={getSuggestionItemId(itemIndex)}
-                textValue={title}
-                className={styles.item}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                }}
-                onPress={() => onItemClick?.(item)}
-              >
-                <span className={clsx(styles.icon, resolveSlashMenuIconColor(item))}>
-                  {resolveSlashMenuIcon(item)}
-                </span>
-                <span className={styles.label}>{title}</span>
-              </ListBoxItem>
-            );
-          })}
-        </ListBoxSection>
-      ))}
+      <SlashMenuListBoxItems
+        items={displayItems}
+        getItemId={(_item, index) => getSuggestionItemId(index)}
+        onItemClick={onItemClick}
+      />
     </ListBox>
   );
 }
@@ -336,14 +70,12 @@ const NoteSlashMenu = ({ editor, plugins }: NoteSlashMenuProps) => {
   }
 
   const getItems = async (query: string) => {
-    const items = [
-      ...getFilteredDefaultReactSlashMenuItems(
-        editor,
-        NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET
-      ),
-      ...collectPluginSlashMenuItems(plugins, editor),
-    ];
-    return filterSuggestionItems(items, query);
+    const items = getNoteSlashMenuItems(
+      editor,
+      plugins,
+      NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET
+    );
+    return sortSuggestionItemsForDisplay(filterSuggestionItems(items, query));
   };
 
   return (
@@ -352,6 +84,11 @@ const NoteSlashMenu = ({ editor, plugins }: NoteSlashMenuProps) => {
         triggerCharacter="/"
         getItems={getItems}
         suggestionMenuComponent={NoteSuggestionMenu}
+        floatingUIOptions={{
+          elementProps: {
+            className: styles.floatingLayer,
+          },
+        }}
         shouldOpen={(state) => !state.selection.$from.parent.type.isInGroup('tableContent')}
       />
     </div>

--- a/src/components/Note/NoteSlashMenu/index.tsx
+++ b/src/components/Note/NoteSlashMenu/index.tsx
@@ -1,9 +1,32 @@
 import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
+import type { DefaultReactSuggestionItem, SuggestionMenuProps } from '@blocknote/react';
 import { SuggestionMenuController } from '@blocknote/react';
+import {
+  Braces,
+  CheckSquare,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Image,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  ListTree,
+  Minus,
+  Smile,
+  Table,
+  TextQuote,
+  Type,
+} from 'lucide-react';
+import { createElement } from 'react';
 import {
   collectPluginSlashMenuItems,
   getFilteredDefaultReactSlashMenuItems,
+  getSlashMenuItemKey,
 } from './buildSlashMenuItems';
 import type { NoteSlashMenuProps } from './index.type';
 import styles from './style.module.less';
@@ -21,6 +44,293 @@ const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS = ['file', 'audio', 'video'] as
 const NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEY_SET = new Set<string>(
   NOTE_EDITOR_HIDDEN_DEFAULT_SLASH_MENU_KEYS
 );
+
+const SLASH_MENU_GROUP_ORDER = ['基础', '常用', '高级', 'AI', '其他'] as const;
+
+const SLASH_MENU_GROUP_LABEL_MAP: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
+  标题: '基础',
+  基础: '基础',
+  基本块: '基础',
+  基础区块: '基础',
+  高级功能: '常用',
+  媒体: '常用',
+  高级: '高级',
+  AI: 'AI',
+  其他: '其他',
+};
+
+const SLASH_MENU_GROUP_BY_KEY: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
+  paragraph: '基础',
+  heading: '基础',
+  heading_2: '基础',
+  heading_3: '基础',
+  heading_4: '基础',
+  heading_5: '基础',
+  heading_6: '基础',
+  numbered_list: '基础',
+  bullet_list: '基础',
+  check_list: '常用',
+  code_block: '基础',
+  quote: '基础',
+  divider: '基础',
+  link: '基础',
+  image: '常用',
+  table: '常用',
+  toggle_list: '常用',
+  toggle_heading: '常用',
+  toggle_heading_2: '常用',
+  toggle_heading_3: '常用',
+  emoji: '常用',
+};
+
+const SLASH_MENU_TITLE_BY_KEY: Record<string, string> = {
+  paragraph: '文本',
+  heading: '一级标题',
+  heading_2: '二级标题',
+  heading_3: '三级标题',
+  heading_4: '四级标题',
+  heading_5: '五级标题',
+  heading_6: '六级标题',
+  numbered_list: '有序列表',
+  bullet_list: '无序列表',
+  check_list: '任务',
+  code_block: '代码块',
+  quote: '引用',
+  divider: '分隔线',
+  link: '链接',
+  image: '图片',
+  table: '表格',
+  toggle_list: '折叠列表',
+  toggle_heading: '可折叠一级标题',
+  toggle_heading_2: '可折叠二级标题',
+  toggle_heading_3: '可折叠三级标题',
+  emoji: 'Emoji',
+};
+
+const SLASH_MENU_ITEM_ORDER = [
+  'paragraph',
+  'heading',
+  'heading_2',
+  'heading_3',
+  'heading_4',
+  'heading_5',
+  'heading_6',
+  'numbered_list',
+  'bullet_list',
+  'check_list',
+  'code_block',
+  'quote',
+  'divider',
+  'link',
+  'image',
+  'table',
+  'toggle_list',
+  'toggle_heading',
+  'toggle_heading_2',
+  'toggle_heading_3',
+  'emoji',
+] as const;
+
+const SLASH_MENU_ICON_MAP: Record<string, typeof Type> = {
+  paragraph: Type,
+  heading: Heading1,
+  heading_2: Heading2,
+  heading_3: Heading3,
+  heading_4: Heading4,
+  heading_5: Heading5,
+  heading_6: Heading6,
+  toggle_heading: Heading1,
+  toggle_heading_2: Heading2,
+  toggle_heading_3: Heading3,
+  quote: TextQuote,
+  toggle_list: ListTree,
+  numbered_list: ListOrdered,
+  bullet_list: List,
+  check_list: CheckSquare,
+  code_block: Braces,
+  divider: Minus,
+  link: LinkIcon,
+  table: Table,
+  image: Image,
+  emoji: Smile,
+};
+
+const SLASH_MENU_ICON_COLOR_BY_KEY: Record<string, string> = {
+  paragraph: 'text-blue-500',
+  heading: 'text-blue-500',
+  heading_2: 'text-blue-500',
+  heading_3: 'text-blue-500',
+  heading_4: 'text-blue-500',
+  heading_5: 'text-blue-500',
+  heading_6: 'text-blue-500',
+  numbered_list: 'text-indigo-500',
+  bullet_list: 'text-indigo-500',
+  check_list: 'text-violet-500',
+  code_block: 'text-emerald-500',
+  quote: 'text-blue-500',
+  divider: 'text-orange-400',
+  link: 'text-blue-500',
+  image: 'text-amber-400',
+  table: 'text-teal-500',
+  toggle_list: 'text-sky-500',
+  toggle_heading: 'text-blue-500',
+  toggle_heading_2: 'text-blue-500',
+  toggle_heading_3: 'text-blue-500',
+  emoji: 'text-pink-500',
+};
+
+const SLASH_MENU_CLASS =
+  'w-[17.5rem] max-h-[min(34rem,calc(100vh-6rem))] overflow-y-auto rounded-lg border border-[var(--border-light)] bg-[var(--overlay)] p-1.5 shadow-lg';
+const SLASH_MENU_GROUP_LABEL_CLASS = 'px-2 py-1 text-xs text-[var(--text-tertiary)]';
+const SLASH_MENU_GROUP_ITEMS_CLASS = 'flex flex-col gap-0.5';
+const SLASH_MENU_ITEM_CLASS =
+  'grid h-9 w-full grid-cols-[2.25rem_minmax(0,1fr)] items-center rounded-md px-2 text-left text-sm text-[var(--overlay-foreground)] outline-none transition-colors hover:bg-[var(--surface-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--primary)]';
+const SLASH_MENU_ITEM_SELECTED_CLASS = 'bg-[var(--surface-secondary)]';
+const SLASH_MENU_ICON_CLASS =
+  'flex h-7 w-7 items-center justify-center [&>svg]:h-[1.125rem] [&>svg]:w-[1.125rem]';
+const SLASH_MENU_EMPTY_CLASS = 'px-4 py-5 text-center text-sm text-[var(--text-tertiary)]';
+
+function cx(...classNames: Array<string | false | null | undefined>) {
+  return classNames.filter(Boolean).join(' ');
+}
+
+function resolveSlashMenuGroup(item: DefaultReactSuggestionItem): string {
+  const key = getSlashMenuItemKey(item);
+  if (key && SLASH_MENU_GROUP_BY_KEY[key]) {
+    return SLASH_MENU_GROUP_BY_KEY[key];
+  }
+  const rawGroup = typeof item.group === 'string' ? item.group : '';
+  return SLASH_MENU_GROUP_LABEL_MAP[rawGroup] ?? rawGroup ?? '其他';
+}
+
+function resolveSlashMenuTitle(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  return key ? (SLASH_MENU_TITLE_BY_KEY[key] ?? item.title) : item.title;
+}
+
+function resolveSlashMenuIconColor(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  if (key && SLASH_MENU_ICON_COLOR_BY_KEY[key]) {
+    return SLASH_MENU_ICON_COLOR_BY_KEY[key];
+  }
+  if (item.group === 'AI') {
+    return 'text-purple-500';
+  }
+  if (item.title === '公式') {
+    return 'text-slate-700';
+  }
+  return 'text-blue-500';
+}
+
+function resolveSlashMenuIcon(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  const Icon = key ? SLASH_MENU_ICON_MAP[key] : undefined;
+  if (Icon) {
+    return createElement(Icon, { size: 18, strokeWidth: 2 });
+  }
+  return item.icon ?? null;
+}
+
+function compareSlashMenuItems(a: DefaultReactSuggestionItem, b: DefaultReactSuggestionItem) {
+  const aKey = getSlashMenuItemKey(a);
+  const bKey = getSlashMenuItemKey(b);
+  const aIndex = aKey
+    ? SLASH_MENU_ITEM_ORDER.indexOf(aKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
+    : -1;
+  const bIndex = bKey
+    ? SLASH_MENU_ITEM_ORDER.indexOf(bKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
+    : -1;
+  if (aIndex !== -1 || bIndex !== -1) {
+    return (
+      (aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex) -
+      (bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex)
+    );
+  }
+  return resolveSlashMenuTitle(a).localeCompare(resolveSlashMenuTitle(b), 'zh-CN');
+}
+
+function groupSuggestionItems(items: DefaultReactSuggestionItem[]) {
+  const groupMap = new Map<string, DefaultReactSuggestionItem[]>();
+  for (const item of [...items].sort(compareSlashMenuItems)) {
+    const group = resolveSlashMenuGroup(item);
+    groupMap.set(group, [...(groupMap.get(group) ?? []), item]);
+  }
+
+  return [...groupMap.entries()].sort(([a], [b]) => {
+    const aIndex = SLASH_MENU_GROUP_ORDER.indexOf(a as (typeof SLASH_MENU_GROUP_ORDER)[number]);
+    const bIndex = SLASH_MENU_GROUP_ORDER.indexOf(b as (typeof SLASH_MENU_GROUP_ORDER)[number]);
+    if (aIndex === -1 && bIndex === -1) {
+      return a.localeCompare(b, 'zh-CN');
+    }
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+}
+
+function NoteSuggestionMenu({
+  items,
+  loadingState,
+  selectedIndex,
+  onItemClick,
+}: SuggestionMenuProps<DefaultReactSuggestionItem>) {
+  if (loadingState === 'loading-initial') {
+    return (
+      <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
+        <div className={SLASH_MENU_EMPTY_CLASS}>加载中...</div>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
+        <div className={SLASH_MENU_EMPTY_CLASS}>无匹配项</div>
+      </div>
+    );
+  }
+
+  const groupedItems = groupSuggestionItems(items);
+  const groupStartIndexes = groupedItems.map(([, groupItems], groupIndex) =>
+    groupedItems
+      .slice(0, groupIndex)
+      .reduce((count, [, previousGroupItems]) => count + previousGroupItems.length, 0)
+  );
+
+  return (
+    <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
+      {groupedItems.map(([group, groupItems], groupIndex) => (
+        <div className="mt-1 first:mt-0" key={group}>
+          <div className={SLASH_MENU_GROUP_LABEL_CLASS}>{group}</div>
+          <div className={SLASH_MENU_GROUP_ITEMS_CLASS}>
+            {groupItems.map((item, itemIndexInGroup) => {
+              const itemIndex = groupStartIndexes[groupIndex] + itemIndexInGroup;
+              const selected = itemIndex === selectedIndex;
+              return (
+                <button
+                  key={`${group}-${resolveSlashMenuTitle(item)}-${itemIndex}`}
+                  type="button"
+                  className={cx(SLASH_MENU_ITEM_CLASS, selected && SLASH_MENU_ITEM_SELECTED_CLASS)}
+                  role="option"
+                  aria-selected={selected}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onClick={() => onItemClick?.(item)}
+                >
+                  <span className={cx(SLASH_MENU_ICON_CLASS, resolveSlashMenuIconColor(item))}>
+                    {resolveSlashMenuIcon(item)}
+                  </span>
+                  <span className="min-w-0 truncate">{resolveSlashMenuTitle(item)}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 const NoteSlashMenu = ({ editor, plugins }: NoteSlashMenuProps) => {
   const readOnly = useNoteEditorReadOnlyContext();
@@ -41,7 +351,12 @@ const NoteSlashMenu = ({ editor, plugins }: NoteSlashMenuProps) => {
 
   return (
     <div className={styles.host}>
-      <SuggestionMenuController triggerCharacter="/" getItems={getItems} />
+      <SuggestionMenuController
+        triggerCharacter="/"
+        getItems={getItems}
+        suggestionMenuComponent={NoteSuggestionMenu}
+        shouldOpen={(state) => !state.selection.$from.parent.type.isInGroup('tableContent')}
+      />
     </div>
   );
 };

--- a/src/components/Note/NoteSlashMenu/index.tsx
+++ b/src/components/Note/NoteSlashMenu/index.tsx
@@ -2,6 +2,8 @@ import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/
 import { filterSuggestionItems } from '@blocknote/core/extensions';
 import type { DefaultReactSuggestionItem, SuggestionMenuProps } from '@blocknote/react';
 import { SuggestionMenuController } from '@blocknote/react';
+import { Header, ListBox, ListBoxItem, ListBoxSection } from '@heroui/react';
+import clsx from 'clsx';
 import {
   Braces,
   CheckSquare,
@@ -156,43 +158,28 @@ const SLASH_MENU_ICON_MAP: Record<string, typeof Type> = {
 };
 
 const SLASH_MENU_ICON_COLOR_BY_KEY: Record<string, string> = {
-  paragraph: 'text-blue-500',
-  heading: 'text-blue-500',
-  heading_2: 'text-blue-500',
-  heading_3: 'text-blue-500',
-  heading_4: 'text-blue-500',
-  heading_5: 'text-blue-500',
-  heading_6: 'text-blue-500',
-  numbered_list: 'text-indigo-500',
-  bullet_list: 'text-indigo-500',
-  check_list: 'text-violet-500',
-  code_block: 'text-emerald-500',
-  quote: 'text-blue-500',
-  divider: 'text-orange-400',
-  link: 'text-blue-500',
-  image: 'text-amber-400',
-  table: 'text-teal-500',
-  toggle_list: 'text-sky-500',
-  toggle_heading: 'text-blue-500',
-  toggle_heading_2: 'text-blue-500',
-  toggle_heading_3: 'text-blue-500',
-  emoji: 'text-pink-500',
+  paragraph: styles.iconPrimary,
+  heading: styles.iconPrimary,
+  heading_2: styles.iconPrimary,
+  heading_3: styles.iconPrimary,
+  heading_4: styles.iconPrimary,
+  heading_5: styles.iconPrimary,
+  heading_6: styles.iconPrimary,
+  numbered_list: styles.iconAccent,
+  bullet_list: styles.iconAccent,
+  check_list: styles.iconSuccess,
+  code_block: styles.iconSuccess,
+  quote: styles.iconPrimary,
+  divider: styles.iconWarning,
+  link: styles.iconPrimary,
+  image: styles.iconWarning,
+  table: styles.iconSuccess,
+  toggle_list: styles.iconPrimary,
+  toggle_heading: styles.iconPrimary,
+  toggle_heading_2: styles.iconPrimary,
+  toggle_heading_3: styles.iconPrimary,
+  emoji: styles.iconAccent,
 };
-
-const SLASH_MENU_CLASS =
-  'w-[17.5rem] max-h-[min(34rem,calc(100vh-6rem))] overflow-y-auto rounded-lg border border-[var(--border-light)] bg-[var(--overlay)] p-1.5 shadow-lg';
-const SLASH_MENU_GROUP_LABEL_CLASS = 'px-2 py-1 text-xs text-[var(--text-tertiary)]';
-const SLASH_MENU_GROUP_ITEMS_CLASS = 'flex flex-col gap-0.5';
-const SLASH_MENU_ITEM_CLASS =
-  'grid h-9 w-full grid-cols-[2.25rem_minmax(0,1fr)] items-center rounded-md px-2 text-left text-sm text-[var(--overlay-foreground)] outline-none transition-colors hover:bg-[var(--surface-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--primary)]';
-const SLASH_MENU_ITEM_SELECTED_CLASS = 'bg-[var(--surface-secondary)]';
-const SLASH_MENU_ICON_CLASS =
-  'flex h-7 w-7 items-center justify-center [&>svg]:h-[1.125rem] [&>svg]:w-[1.125rem]';
-const SLASH_MENU_EMPTY_CLASS = 'px-4 py-5 text-center text-sm text-[var(--text-tertiary)]';
-
-function cx(...classNames: Array<string | false | null | undefined>) {
-  return classNames.filter(Boolean).join(' ');
-}
 
 function resolveSlashMenuGroup(item: DefaultReactSuggestionItem): string {
   const key = getSlashMenuItemKey(item);
@@ -214,12 +201,12 @@ function resolveSlashMenuIconColor(item: DefaultReactSuggestionItem) {
     return SLASH_MENU_ICON_COLOR_BY_KEY[key];
   }
   if (item.group === 'AI') {
-    return 'text-purple-500';
+    return styles.iconAccent;
   }
   if (item.title === '公式') {
-    return 'text-slate-700';
+    return styles.iconMuted;
   }
-  return 'text-blue-500';
+  return styles.iconPrimary;
 }
 
 function resolveSlashMenuIcon(item: DefaultReactSuggestionItem) {
@@ -268,6 +255,20 @@ function groupSuggestionItems(items: DefaultReactSuggestionItem[]) {
   });
 }
 
+function getSuggestionItemId(index: number) {
+  return `slash-item-${index}`;
+}
+
+function SlashMenuState({ text }: { text: string }) {
+  return (
+    <ListBox aria-label="斜杠菜单" className={styles.menu}>
+      <ListBoxItem id="slash-menu-state" textValue={text} isDisabled className={styles.emptyItem}>
+        {text}
+      </ListBoxItem>
+    </ListBox>
+  );
+}
+
 function NoteSuggestionMenu({
   items,
   loadingState,
@@ -275,19 +276,11 @@ function NoteSuggestionMenu({
   onItemClick,
 }: SuggestionMenuProps<DefaultReactSuggestionItem>) {
   if (loadingState === 'loading-initial') {
-    return (
-      <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
-        <div className={SLASH_MENU_EMPTY_CLASS}>加载中...</div>
-      </div>
-    );
+    return <SlashMenuState text="加载中..." />;
   }
 
   if (items.length === 0) {
-    return (
-      <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
-        <div className={SLASH_MENU_EMPTY_CLASS}>无匹配项</div>
-      </div>
-    );
+    return <SlashMenuState text="无匹配项" />;
   }
 
   const groupedItems = groupSuggestionItems(items);
@@ -296,39 +289,43 @@ function NoteSuggestionMenu({
       .slice(0, groupIndex)
       .reduce((count, [, previousGroupItems]) => count + previousGroupItems.length, 0)
   );
+  const selectedItemIndex = selectedIndex ?? -1;
+  const selectedKey = selectedItemIndex >= 0 ? getSuggestionItemId(selectedItemIndex) : undefined;
 
   return (
-    <div className={SLASH_MENU_CLASS} role="listbox" aria-label="斜杠菜单">
+    <ListBox
+      aria-label="斜杠菜单"
+      selectionMode="single"
+      selectedKeys={selectedKey ? [selectedKey] : []}
+      className={styles.menu}
+    >
       {groupedItems.map(([group, groupItems], groupIndex) => (
-        <div className="mt-1 first:mt-0" key={group}>
-          <div className={SLASH_MENU_GROUP_LABEL_CLASS}>{group}</div>
-          <div className={SLASH_MENU_GROUP_ITEMS_CLASS}>
-            {groupItems.map((item, itemIndexInGroup) => {
-              const itemIndex = groupStartIndexes[groupIndex] + itemIndexInGroup;
-              const selected = itemIndex === selectedIndex;
-              return (
-                <button
-                  key={`${group}-${resolveSlashMenuTitle(item)}-${itemIndex}`}
-                  type="button"
-                  className={cx(SLASH_MENU_ITEM_CLASS, selected && SLASH_MENU_ITEM_SELECTED_CLASS)}
-                  role="option"
-                  aria-selected={selected}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                  }}
-                  onClick={() => onItemClick?.(item)}
-                >
-                  <span className={cx(SLASH_MENU_ICON_CLASS, resolveSlashMenuIconColor(item))}>
-                    {resolveSlashMenuIcon(item)}
-                  </span>
-                  <span className="min-w-0 truncate">{resolveSlashMenuTitle(item)}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
+        <ListBoxSection id={`slash-group-${group}`} className={styles.section} key={group}>
+          <Header className={styles.sectionTitle}>{group}</Header>
+          {groupItems.map((item, itemIndexInGroup) => {
+            const itemIndex = groupStartIndexes[groupIndex] + itemIndexInGroup;
+            const title = resolveSlashMenuTitle(item);
+            return (
+              <ListBoxItem
+                key={getSuggestionItemId(itemIndex)}
+                id={getSuggestionItemId(itemIndex)}
+                textValue={title}
+                className={styles.item}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+                onPress={() => onItemClick?.(item)}
+              >
+                <span className={clsx(styles.icon, resolveSlashMenuIconColor(item))}>
+                  {resolveSlashMenuIcon(item)}
+                </span>
+                <span className={styles.label}>{title}</span>
+              </ListBoxItem>
+            );
+          })}
+        </ListBoxSection>
       ))}
-    </div>
+    </ListBox>
   );
 }
 

--- a/src/components/Note/NoteSlashMenu/slashMenuModel.ts
+++ b/src/components/Note/NoteSlashMenu/slashMenuModel.ts
@@ -1,0 +1,143 @@
+import type { DefaultReactSuggestionItem } from '@blocknote/react';
+import { getSlashMenuItemKey } from './buildSlashMenuItems';
+
+const SLASH_MENU_GROUP_ORDER = ['基础', '常用', '高级', 'AI', '其他'] as const;
+
+const SLASH_MENU_GROUP_LABEL_MAP: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
+  标题: '基础',
+  基础: '基础',
+  基本块: '基础',
+  基础区块: '基础',
+  高级功能: '常用',
+  媒体: '常用',
+  高级: '高级',
+  AI: 'AI',
+  其他: '其他',
+};
+
+const SLASH_MENU_GROUP_BY_KEY: Record<string, (typeof SLASH_MENU_GROUP_ORDER)[number]> = {
+  paragraph: '基础',
+  heading: '基础',
+  heading_2: '基础',
+  heading_3: '基础',
+  heading_4: '基础',
+  heading_5: '基础',
+  heading_6: '基础',
+  numbered_list: '基础',
+  bullet_list: '基础',
+  check_list: '常用',
+  code_block: '基础',
+  quote: '基础',
+  divider: '基础',
+  link: '基础',
+  image: '常用',
+  table: '常用',
+  toggle_list: '常用',
+  toggle_heading: '常用',
+  toggle_heading_2: '常用',
+  toggle_heading_3: '常用',
+  emoji: '常用',
+};
+
+const SLASH_MENU_TITLE_BY_KEY: Record<string, string> = {
+  paragraph: '文本',
+  heading: '一级标题',
+  heading_2: '二级标题',
+  heading_3: '三级标题',
+  heading_4: '四级标题',
+  heading_5: '五级标题',
+  heading_6: '六级标题',
+  numbered_list: '有序列表',
+  bullet_list: '无序列表',
+  check_list: '任务',
+  code_block: '代码块',
+  quote: '引用',
+  divider: '分隔线',
+  link: '链接',
+  image: '图片',
+  table: '表格',
+  toggle_list: '折叠列表',
+  toggle_heading: '可折叠一级标题',
+  toggle_heading_2: '可折叠二级标题',
+  toggle_heading_3: '可折叠三级标题',
+  emoji: 'Emoji',
+};
+
+const SLASH_MENU_ITEM_ORDER = [
+  'paragraph',
+  'heading',
+  'heading_2',
+  'heading_3',
+  'heading_4',
+  'heading_5',
+  'heading_6',
+  'numbered_list',
+  'bullet_list',
+  'check_list',
+  'code_block',
+  'quote',
+  'divider',
+  'link',
+  'image',
+  'table',
+  'toggle_list',
+  'toggle_heading',
+  'toggle_heading_2',
+  'toggle_heading_3',
+  'emoji',
+] as const;
+
+export function resolveSlashMenuGroup(item: DefaultReactSuggestionItem): string {
+  const key = getSlashMenuItemKey(item);
+  if (key && SLASH_MENU_GROUP_BY_KEY[key]) {
+    return SLASH_MENU_GROUP_BY_KEY[key];
+  }
+  const rawGroup = typeof item.group === 'string' ? item.group : '';
+  return SLASH_MENU_GROUP_LABEL_MAP[rawGroup] ?? rawGroup ?? '其他';
+}
+
+export function resolveSlashMenuTitle(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  return key ? (SLASH_MENU_TITLE_BY_KEY[key] ?? item.title) : item.title;
+}
+
+function compareSlashMenuItems(a: DefaultReactSuggestionItem, b: DefaultReactSuggestionItem) {
+  const aKey = getSlashMenuItemKey(a);
+  const bKey = getSlashMenuItemKey(b);
+  const aIndex = aKey
+    ? SLASH_MENU_ITEM_ORDER.indexOf(aKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
+    : -1;
+  const bIndex = bKey
+    ? SLASH_MENU_ITEM_ORDER.indexOf(bKey as (typeof SLASH_MENU_ITEM_ORDER)[number])
+    : -1;
+  if (aIndex !== -1 || bIndex !== -1) {
+    return (
+      (aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex) -
+      (bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex)
+    );
+  }
+  return resolveSlashMenuTitle(a).localeCompare(resolveSlashMenuTitle(b), 'zh-CN');
+}
+
+export function sortSuggestionItemsForDisplay(items: DefaultReactSuggestionItem[]) {
+  return [...items].sort(compareSlashMenuItems);
+}
+
+export function groupSuggestionItems(items: DefaultReactSuggestionItem[]) {
+  const groupMap = new Map<string, DefaultReactSuggestionItem[]>();
+  for (const item of sortSuggestionItemsForDisplay(items)) {
+    const group = resolveSlashMenuGroup(item);
+    groupMap.set(group, [...(groupMap.get(group) ?? []), item]);
+  }
+
+  return [...groupMap.entries()].sort(([a], [b]) => {
+    const aIndex = SLASH_MENU_GROUP_ORDER.indexOf(a as (typeof SLASH_MENU_GROUP_ORDER)[number]);
+    const bIndex = SLASH_MENU_GROUP_ORDER.indexOf(b as (typeof SLASH_MENU_GROUP_ORDER)[number]);
+    if (aIndex === -1 && bIndex === -1) {
+      return a.localeCompare(b, 'zh-CN');
+    }
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+}

--- a/src/components/Note/NoteSlashMenu/slashMenuView.tsx
+++ b/src/components/Note/NoteSlashMenu/slashMenuView.tsx
@@ -1,0 +1,180 @@
+import type { DefaultReactSuggestionItem } from '@blocknote/react';
+import { Dropdown, Header, ListBoxItem, ListBoxSection } from '@heroui/react';
+import clsx from 'clsx';
+import {
+  Braces,
+  CheckSquare,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Image,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  ListTree,
+  Minus,
+  Smile,
+  Table2,
+  TextQuote,
+  Type,
+} from 'lucide-react';
+import { createElement } from 'react';
+import { getSlashMenuItemKey } from './buildSlashMenuItems';
+import { groupSuggestionItems, resolveSlashMenuTitle } from './slashMenuModel';
+import styles from './style.module.less';
+
+const SLASH_MENU_ICON_MAP: Record<string, typeof Type> = {
+  paragraph: Type,
+  heading: Heading1,
+  heading_2: Heading2,
+  heading_3: Heading3,
+  heading_4: Heading4,
+  heading_5: Heading5,
+  heading_6: Heading6,
+  toggle_heading: Heading1,
+  toggle_heading_2: Heading2,
+  toggle_heading_3: Heading3,
+  quote: TextQuote,
+  toggle_list: ListTree,
+  numbered_list: ListOrdered,
+  bullet_list: List,
+  check_list: CheckSquare,
+  code_block: Braces,
+  divider: Minus,
+  link: LinkIcon,
+  table: Table2,
+  image: Image,
+  emoji: Smile,
+};
+
+const SLASH_MENU_ICON_COLOR_BY_KEY: Record<string, string> = {
+  divider: styles.iconWarning,
+  check_list: styles.iconSuccess,
+  code_block: styles.iconSuccess,
+  image: styles.iconWarning,
+  table: styles.iconSuccess,
+  emoji: styles.iconAccent,
+};
+
+function resolveSlashMenuIconColor(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  if (key && SLASH_MENU_ICON_COLOR_BY_KEY[key]) {
+    return SLASH_MENU_ICON_COLOR_BY_KEY[key];
+  }
+  if (item.group === 'AI') {
+    return styles.iconAccent;
+  }
+  if (item.title === '公式') {
+    return styles.iconMuted;
+  }
+  return styles.iconTheme;
+}
+
+function resolveSlashMenuIcon(item: DefaultReactSuggestionItem) {
+  const key = getSlashMenuItemKey(item);
+  const Icon = key ? SLASH_MENU_ICON_MAP[key] : undefined;
+  if (Icon) {
+    return createElement(Icon, { size: 18, strokeWidth: 2 });
+  }
+  return item.icon ?? null;
+}
+
+export function SlashMenuItemContent({ item }: { item: DefaultReactSuggestionItem }) {
+  return (
+    <>
+      <span className={clsx(styles.icon, resolveSlashMenuIconColor(item))}>
+        {resolveSlashMenuIcon(item)}
+      </span>
+      <span className={styles.label}>{resolveSlashMenuTitle(item)}</span>
+    </>
+  );
+}
+
+export function SlashMenuDropdownItems({
+  getItemId,
+  items,
+}: {
+  getItemId: (item: DefaultReactSuggestionItem, index: number) => string;
+  items: DefaultReactSuggestionItem[];
+}) {
+  const groupedItems = groupSuggestionItems(items);
+
+  return (
+    <>
+      {groupedItems.map(([group, groupItems], groupIndex) => {
+        const currentOffset = groupedItems
+          .slice(0, groupIndex)
+          .reduce((count, [, previousGroupItems]) => count + previousGroupItems.length, 0);
+
+        return (
+          <Dropdown.Section id={`slash-group-${group}`} className={styles.section} key={group}>
+            <Header className={styles.sectionTitle}>{group}</Header>
+            {groupItems.map((item, itemIndexInGroup) => {
+              const itemIndex = currentOffset + itemIndexInGroup;
+              const title = resolveSlashMenuTitle(item);
+
+              return (
+                <Dropdown.Item
+                  key={getItemId(item, itemIndex)}
+                  id={getItemId(item, itemIndex)}
+                  textValue={title}
+                  className={styles.item}
+                >
+                  <SlashMenuItemContent item={item} />
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Section>
+        );
+      })}
+    </>
+  );
+}
+
+export function SlashMenuListBoxItems({
+  getItemId,
+  items,
+  onItemClick,
+}: {
+  getItemId: (item: DefaultReactSuggestionItem, index: number) => string;
+  items: DefaultReactSuggestionItem[];
+  onItemClick?: (item: DefaultReactSuggestionItem) => void;
+}) {
+  const groupedItems = groupSuggestionItems(items);
+
+  return (
+    <>
+      {groupedItems.map(([group, groupItems], groupIndex) => {
+        const currentOffset = groupedItems
+          .slice(0, groupIndex)
+          .reduce((count, [, previousGroupItems]) => count + previousGroupItems.length, 0);
+
+        return (
+          <ListBoxSection id={`slash-group-${group}`} className={styles.section} key={group}>
+            <Header className={styles.sectionTitle}>{group}</Header>
+            {groupItems.map((item, itemIndexInGroup) => {
+              const itemIndex = currentOffset + itemIndexInGroup;
+              const title = resolveSlashMenuTitle(item);
+
+              return (
+                <ListBoxItem
+                  key={getItemId(item, itemIndex)}
+                  id={getItemId(item, itemIndex)}
+                  textValue={title}
+                  className={styles.item}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onPress={() => onItemClick?.(item)}
+                >
+                  <SlashMenuItemContent item={item} />
+                </ListBoxItem>
+              );
+            })}
+          </ListBoxSection>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/Note/NoteSlashMenu/style.module.less
+++ b/src/components/Note/NoteSlashMenu/style.module.less
@@ -2,6 +2,10 @@
   display: contents;
 }
 
+.floatingLayer {
+  z-index: var(--note-editor-menu-layer, 80);
+}
+
 .menu {
   --note-slash-menu-width: 17.5rem;
   --note-slash-menu-max-height: min(
@@ -62,6 +66,27 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: var(--muted);
+}
+
+.iconTheme {
+  color: var(--accent);
+}
+
+.iconAccent {
+  color: var(--accent);
+}
+
+.iconSuccess {
+  color: var(--success);
+}
+
+.iconWarning {
+  color: var(--warning);
+}
+
+.iconMuted {
+  color: var(--muted);
 }
 
 .label {
@@ -79,24 +104,4 @@
   color: var(--text-tertiary);
   font-size: var(--font-size-sm);
   line-height: var(--line-height-sm);
-}
-
-.iconPrimary {
-  color: var(--primary);
-}
-
-.iconAccent {
-  color: var(--accent);
-}
-
-.iconSuccess {
-  color: var(--success);
-}
-
-.iconWarning {
-  color: var(--warning);
-}
-
-.iconMuted {
-  color: var(--muted);
 }

--- a/src/components/Note/NoteSlashMenu/style.module.less
+++ b/src/components/Note/NoteSlashMenu/style.module.less
@@ -1,3 +1,102 @@
 .host {
   display: contents;
 }
+
+.menu {
+  --note-slash-menu-width: 17.5rem;
+  --note-slash-menu-max-height: min(
+    34rem,
+    calc(100vh - var(--space-2xl) - var(--space-xl))
+  );
+
+  width: var(--note-slash-menu-width);
+  max-height: var(--note-slash-menu-max-height);
+  overflow-y: auto;
+  padding: var(--app-popover-content-padding, var(--space-xs));
+  border: 1px solid var(--border-light);
+  border-radius: var(--app-radius-popover, min(32px, var(--radius-3xl)));
+  background: var(--overlay);
+  box-shadow: var(--overlay-shadow);
+}
+
+.section + .section {
+  margin-top: var(--space-2xs);
+}
+
+.sectionTitle {
+  display: block;
+  padding: var(--space-2xs) var(--space-xs);
+  color: var(--text-tertiary);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-xs);
+}
+
+.item {
+  min-height: var(--control-height);
+  display: grid;
+  grid-template-columns: var(--control-height) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 0 var(--space-xs);
+  border-radius: var(--app-radius-popover-item, var(--radius-xl));
+  color: var(--overlay-foreground);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.item:hover,
+.item[data-hovered],
+.item[data-focused],
+.item[data-selected] {
+  background: var(--surface-secondary);
+}
+
+.item[data-focus-visible] {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+
+.icon {
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emptyItem {
+  min-height: var(--control-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.iconPrimary {
+  color: var(--primary);
+}
+
+.iconAccent {
+  color: var(--accent);
+}
+
+.iconSuccess {
+  color: var(--success);
+}
+
+.iconWarning {
+  color: var(--warning);
+}
+
+.iconMuted {
+  color: var(--muted);
+}

--- a/src/components/Note/NoteTableHandles/index.tsx
+++ b/src/components/Note/NoteTableHandles/index.tsx
@@ -1,0 +1,690 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
+import {
+  getSafeTableCellSelection,
+  getTableHandles,
+  hasMountedEditorView,
+} from '@/components/Note/tableHandlesSafe';
+import {
+  isTableCellSelection,
+  mapTableCell,
+  type InlineContentSchema,
+  type StyleSchema,
+  type TableContent,
+} from '@blocknote/core';
+import { TableHandlesExtension } from '@blocknote/core/extensions';
+import {
+  TableCellButton,
+  TableHandlesController,
+  useBlockNoteEditor,
+  useEditorState,
+  useExtensionState,
+  type TableCellButtonProps,
+} from '@blocknote/react';
+import { Button, Tooltip } from '@heroui/react';
+import { useEventListener, useMount, useUnmount, useUpdateEffect } from 'ahooks';
+import { Plus, Table2 } from 'lucide-react';
+import { useRef, useState, type CSSProperties, type MouseEvent, type PointerEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { tableRailSelectionState } from './railSelectionState';
+import styles from './style.module.less';
+
+type RowInsertTarget = { orientation: 'row'; index: number; side: 'above' | 'below' };
+type ColumnInsertTarget = { orientation: 'column'; index: number; side: 'left' | 'right' };
+type InsertTarget = RowInsertTarget | ColumnInsertTarget | null;
+type SelectionTarget = { orientation: 'row' | 'column'; index: number };
+type SelectionDragTarget = SelectionTarget | null;
+type SelectionRange = { orientation: 'row' | 'column'; startIndex: number; endIndex: number };
+
+function getTargetKey(target: Exclude<InsertTarget, null>) {
+  return `${target.orientation}:${target.index}:${target.side}`;
+}
+
+function getSelectionTargetKey(target: SelectionTarget) {
+  return `${target.orientation}:${target.index}`;
+}
+
+function NoteTableCellHandle(props: TableCellButtonProps) {
+  return (
+    <TableCellButton {...props}>
+      <span className={styles.tableCellHandleIcon} aria-hidden="true">
+        <Table2 size={14} />
+      </span>
+    </TableCellButton>
+  );
+}
+
+function useEditorViewReady() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const [viewReady, setViewReady] = useState(() => hasMountedEditorView(editor));
+  const animationFrameRef = useRef(0);
+  const disposedRef = useRef(false);
+
+  useMount(() => {
+    disposedRef.current = false;
+    const update = () => {
+      if (disposedRef.current) {
+        return;
+      }
+
+      const nextViewReady = hasMountedEditorView(editor);
+      setViewReady(nextViewReady);
+      if (!nextViewReady) {
+        animationFrameRef.current = window.requestAnimationFrame(update);
+      }
+    };
+
+    update();
+  });
+
+  useUnmount(() => {
+    disposedRef.current = true;
+    if (animationFrameRef.current) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = 0;
+    }
+  });
+
+  return viewReady;
+}
+
+function TableInsertHandles() {
+  const viewReady = useEditorViewReady();
+
+  if (!viewReady) {
+    return null;
+  }
+
+  return <MountedTableInsertHandles />;
+}
+
+function MountedTableInsertHandles() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const tableHandles = getTableHandles(editor);
+  const state = useExtensionState(TableHandlesExtension, { editor });
+  const isSelectingTableCells = useEditorState({
+    editor,
+    selector: ({ editor }) => isTableCellSelection(editor.prosemirrorState.selection),
+  });
+  const [activeTarget, setActiveTarget] = useState<InsertTarget>(null);
+  const [railSelectionRange, setRailSelectionRange] = useState<SelectionRange | null>(null);
+  const activeInsertKeyRef = useRef<string | null>(null);
+  const isPressingInsertRef = useRef(false);
+  const hoveredSelectionKeyRef = useRef<string | null>(null);
+  const dragSelectionRef = useRef<SelectionDragTarget>(null);
+  const didDragSelectionRef = useRef(false);
+
+  useUnmount(() => {
+    dragSelectionRef.current = null;
+    isPressingInsertRef.current = false;
+    tableRailSelectionState.clear();
+    tableHandles?.unfreezeHandles();
+  });
+
+  useUpdateEffect(() => {
+    if (isSelectingTableCells) {
+      return;
+    }
+    dragSelectionRef.current = null;
+    setRailSelectionRange(null);
+    tableRailSelectionState.clear();
+  }, [isSelectingTableCells]);
+
+  useEventListener('pointerup', () => {
+    if (isPressingInsertRef.current) {
+      window.setTimeout(() => {
+        if (!isPressingInsertRef.current) {
+          return;
+        }
+        isPressingInsertRef.current = false;
+        activeInsertKeyRef.current = null;
+        setActiveTarget(null);
+        tableHandles?.unfreezeHandles();
+      });
+      return;
+    }
+    dragSelectionRef.current = null;
+    tableHandles?.unfreezeHandles();
+  });
+
+  if (!state?.show || !state.referencePosTable || !tableHandles || !editor.isEditable) {
+    return null;
+  }
+
+  const tableElement = state.widgetContainer?.closest('.tableWrapper')?.querySelector('table');
+  const tableWrapper = state.widgetContainer?.closest('.tableWrapper');
+  const portalContainer = tableWrapper?.closest<HTMLElement>('.bn-block-content');
+  const rows = tableElement
+    ? Array.from(tableElement.querySelectorAll<HTMLTableRowElement>('tbody > tr'))
+    : [];
+  const tableContent = state.block.content as TableContent<InlineContentSchema, StyleSchema>;
+  const tableRect = tableElement?.getBoundingClientRect();
+  const containerRect = portalContainer?.getBoundingClientRect();
+
+  if (!tableWrapper || !portalContainer || !tableRect || !containerRect) {
+    return null;
+  }
+
+  const insert = (target: Exclude<InsertTarget, null>) => {
+    setActiveTarget(null);
+    setRailSelectionRange(null);
+    tableRailSelectionState.clear();
+    tableHandles.addRowOrColumn(
+      target.index,
+      target.orientation === 'row'
+        ? { orientation: 'row', side: target.side }
+        : { orientation: 'column', side: target.side }
+    );
+    window.setTimeout(() => editor.focus());
+  };
+  const tableLeft = tableRect.left - containerRect.left;
+  const tableTop = tableRect.top - containerRect.top;
+  const tableRight = tableRect.right - containerRect.left;
+  const tableBottom = tableRect.bottom - containerRect.top;
+  const tableWidth = tableRect.width;
+  const tableHeight = tableRect.height;
+  const blockStyle = window.getComputedStyle(portalContainer);
+  const selectionRailSize =
+    Number.parseFloat(blockStyle.getPropertyValue('--note-table-select-rail-size')) || 8;
+  const logicalColumnCount = Math.max(
+    0,
+    ...tableContent.rows.map((row) =>
+      row.cells.reduce((count, cell) => count + (mapTableCell(cell).props.colspan ?? 1), 0)
+    )
+  );
+  const getActualCellIndexForLogicalColumn = (rowIndex: number, logicalColumnIndex: number) => {
+    const row = tableContent.rows[rowIndex];
+    if (!row) {
+      return 0;
+    }
+    let startColumn = 0;
+    for (let cellIndex = 0; cellIndex < row.cells.length; cellIndex += 1) {
+      const colspan = mapTableCell(row.cells[cellIndex]).props.colspan ?? 1;
+      if (logicalColumnIndex >= startColumn && logicalColumnIndex < startColumn + colspan) {
+        return cellIndex;
+      }
+      startColumn += colspan;
+    }
+    return Math.max(row.cells.length - 1, 0);
+  };
+  const getLastActualCellIndexForRow = (rowIndex: number) =>
+    Math.max((tableContent.rows[rowIndex]?.cells.length ?? 1) - 1, 0);
+  const getColumnBoundaries = () => {
+    if (!logicalColumnCount) {
+      return [];
+    }
+
+    const boundaries = [tableLeft, tableRight];
+    for (const row of rows) {
+      for (const cell of Array.from(row.children)) {
+        if (!(cell instanceof HTMLElement)) {
+          continue;
+        }
+        const rect = cell.getBoundingClientRect();
+        boundaries.push(rect.left - containerRect.left, rect.right - containerRect.left);
+      }
+    }
+
+    const mergedBoundaries = boundaries
+      .sort((a, b) => a - b)
+      .reduce<number[]>((result, value) => {
+        const previous = result.at(-1);
+        if (previous == null || Math.abs(previous - value) > 1) {
+          result.push(value);
+        }
+        return result;
+      }, []);
+
+    if (mergedBoundaries.length === logicalColumnCount + 1) {
+      return mergedBoundaries;
+    }
+
+    const fallbackColumnWidth = tableWidth / logicalColumnCount;
+    return Array.from(
+      { length: logicalColumnCount + 1 },
+      (_, index) => tableLeft + fallbackColumnWidth * index
+    );
+  };
+  const columnBoundaryPositions = getColumnBoundaries();
+  const columnMetrics = columnBoundaryPositions.slice(0, -1).map((left, index) => ({
+    key: `column-${index}`,
+    target: { orientation: 'column', index } satisfies SelectionTarget,
+    left,
+    width: columnBoundaryPositions[index + 1] - left,
+  }));
+  const activeTargetKey = activeTarget ? getTargetKey(activeTarget) : null;
+  const cellSelection = getSafeTableCellSelection(editor);
+  const selectedRailKeysFromCellSelection =
+    cellSelection && cellSelection.cells.length > 0
+      ? (() => {
+          const selectedRows = new Set(cellSelection.cells.map((cell) => cell.row));
+          const selectedColumns = new Set(cellSelection.cells.map((cell) => cell.col));
+          const railKeys = new Set<string>();
+          for (const row of selectedRows) {
+            if (selectedColumns.size === (tableContent.rows[row]?.cells.length ?? 0)) {
+              railKeys.add(getSelectionTargetKey({ orientation: 'row', index: row }));
+            }
+          }
+          if (selectedColumns.size === 1 && selectedRows.size === rows.length) {
+            const [actualColumnIndex] = [...selectedColumns];
+            const logicalColumnIndex = columnMetrics.find((column) =>
+              rows.some(
+                (_, rowIndex) =>
+                  getActualCellIndexForLogicalColumn(rowIndex, column.target.index) ===
+                  actualColumnIndex
+              )
+            )?.target.index;
+            if (logicalColumnIndex != null) {
+              railKeys.add(
+                getSelectionTargetKey({ orientation: 'column', index: logicalColumnIndex })
+              );
+            }
+          }
+          return railKeys;
+        })()
+      : new Set<string>();
+  const selectedRailKeys = railSelectionRange
+    ? (() => {
+        const keys = new Set<string>(selectedRailKeysFromCellSelection);
+        const start = Math.min(railSelectionRange.startIndex, railSelectionRange.endIndex);
+        const end = Math.max(railSelectionRange.startIndex, railSelectionRange.endIndex);
+        for (let index = start; index <= end; index += 1) {
+          keys.add(getSelectionTargetKey({ orientation: railSelectionRange.orientation, index }));
+        }
+        return keys;
+      })()
+    : selectedRailKeysFromCellSelection;
+
+  const rowBoundaries = rows.length
+    ? [
+        {
+          key: 'row-before-0',
+          top: tableTop,
+          target: { orientation: 'row', index: 0, side: 'above' } satisfies RowInsertTarget,
+        },
+        ...rows.map((row, index) => ({
+          key: `row-after-${index}`,
+          top: row.getBoundingClientRect().bottom - containerRect.top,
+          target: { orientation: 'row', index, side: 'below' } satisfies RowInsertTarget,
+        })),
+      ]
+    : [];
+
+  const columnBoundaries = columnBoundaryPositions.length
+    ? [
+        {
+          key: 'column-before-0',
+          left: columnBoundaryPositions[0],
+          target: {
+            orientation: 'column',
+            index: 0,
+            side: 'left',
+          } satisfies ColumnInsertTarget,
+        },
+        ...columnBoundaryPositions.slice(1).map((left, index) => ({
+          key: `column-after-${index}`,
+          left,
+          target: {
+            orientation: 'column',
+            index,
+            side: 'right',
+          } satisfies ColumnInsertTarget,
+        })),
+      ]
+    : [];
+
+  const rowRails = rows.map((row, index) => ({
+    key: `select-row-${index}`,
+    target: { orientation: 'row', index } satisfies SelectionTarget,
+    top: row.getBoundingClientRect().top - containerRect.top,
+    height: row.getBoundingClientRect().height,
+  }));
+
+  const columnRails = columnMetrics.map((column) => ({
+    key: `select-${column.key}`,
+    target: column.target,
+    left: column.left,
+    width: column.width,
+  }));
+
+  const getSelectionRange = (target: SelectionTarget, endIndex = target.index) => {
+    if (target.orientation === 'row') {
+      const startRow = Math.min(target.index, endIndex);
+      const endRow = Math.max(target.index, endIndex);
+      return {
+        from: { row: startRow, col: 0 },
+        to: {
+          row: endRow,
+          col: getLastActualCellIndexForRow(endRow),
+        },
+      };
+    }
+
+    const startColumn = Math.min(target.index, endIndex);
+    const endColumn = Math.max(target.index, endIndex);
+    const rowRange = {
+      start: 0,
+      end: Math.max(rows.length - 1, 0),
+    };
+
+    return {
+      from: {
+        row: rowRange.start,
+        col: getActualCellIndexForLogicalColumn(rowRange.start, startColumn),
+      },
+      to: {
+        row: rowRange.end,
+        col: getActualCellIndexForLogicalColumn(rowRange.end, endColumn),
+      },
+    };
+  };
+
+  const selectCells = (target: SelectionTarget, endIndex = target.index) => {
+    const railReferenceRect = getRailReferenceRect(target, endIndex);
+    setRailSelectionRange({
+      orientation: target.orientation,
+      startIndex: target.index,
+      endIndex,
+    });
+    if (railReferenceRect) {
+      tableRailSelectionState.setSelection(target.orientation, railReferenceRect, {
+        blockId: state.block.id,
+        endIndex,
+        startIndex: target.index,
+      });
+    }
+    const range = getSelectionRange(target, endIndex);
+    editor.exec((beforeState, dispatch) => {
+      const nextState = tableHandles.setCellSelection(beforeState, range.from, range.to);
+      dispatch?.(beforeState.tr.setSelection(nextState.selection));
+      return true;
+    });
+  };
+
+  const holdSelectionHandles = () => {
+    tableHandles.freezeHandles();
+  };
+
+  const getRailReferenceRect = (target: SelectionTarget, endIndex = target.index) => {
+    const startIndex = Math.min(target.index, endIndex);
+    const lastIndex = Math.max(target.index, endIndex);
+
+    if (target.orientation === 'row') {
+      const firstRow = rows[startIndex];
+      const lastRow = rows[lastIndex];
+      if (!firstRow || !lastRow) {
+        return undefined;
+      }
+      const firstRowRect = firstRow.getBoundingClientRect();
+      const lastRowRect = lastRow.getBoundingClientRect();
+      return {
+        x: tableRect.left - selectionRailSize,
+        y: firstRowRect.top,
+        width: selectionRailSize,
+        height: lastRowRect.bottom - firstRowRect.top,
+      };
+    }
+
+    const left = columnBoundaryPositions[startIndex];
+    const right = columnBoundaryPositions[lastIndex + 1];
+    if (left == null || right == null) {
+      return undefined;
+    }
+
+    return {
+      x: containerRect.left + left,
+      y: tableRect.top - selectionRailSize,
+      width: right - left,
+      height: selectionRailSize,
+    };
+  };
+
+  const handleSelectionPointerEnter = (target: SelectionTarget) => {
+    if (activeInsertKeyRef.current) {
+      return;
+    }
+    hoveredSelectionKeyRef.current = getSelectionTargetKey(target);
+    holdSelectionHandles();
+    const dragTarget = dragSelectionRef.current;
+    if (dragTarget?.orientation === target.orientation) {
+      if (dragTarget.index !== target.index) {
+        didDragSelectionRef.current = true;
+      }
+      selectCells(dragTarget, target.index);
+    }
+  };
+
+  const handleSelectionPointerLeave = (target: SelectionTarget) => {
+    const key = getSelectionTargetKey(target);
+    if (hoveredSelectionKeyRef.current === key) {
+      hoveredSelectionKeyRef.current = null;
+    }
+    tableHandles.unfreezeHandles();
+  };
+
+  const handleInsertPointerEnter = (target: Exclude<InsertTarget, null>) => {
+    activeInsertKeyRef.current = getTargetKey(target);
+    setActiveTarget(target);
+    tableHandles.freezeHandles();
+  };
+
+  const handleInsertPointerLeave = (target: Exclude<InsertTarget, null>) => {
+    const key = getTargetKey(target);
+    if (activeInsertKeyRef.current === key) {
+      activeInsertKeyRef.current = null;
+    }
+    setActiveTarget((current) => (current && getTargetKey(current) === key ? null : current));
+    if (!hoveredSelectionKeyRef.current && !isPressingInsertRef.current) {
+      tableHandles.unfreezeHandles();
+    }
+  };
+
+  const handleSelectionPointerDown = (
+    event: PointerEvent<HTMLButtonElement>,
+    target: SelectionTarget
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (activeInsertKeyRef.current) {
+      return;
+    }
+    dragSelectionRef.current = target;
+    didDragSelectionRef.current = false;
+    tableHandles.freezeHandles();
+    selectCells(target);
+  };
+
+  const handleSelectionClick = (event: MouseEvent<HTMLButtonElement>, target: SelectionTarget) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (didDragSelectionRef.current) {
+      didDragSelectionRef.current = false;
+      return;
+    }
+    if (!activeInsertKeyRef.current) {
+      selectCells(target);
+    }
+  };
+
+  const handleInsertPointerDown = (
+    event: PointerEvent<Element>,
+    target: Exclude<InsertTarget, null>
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isPressingInsertRef.current = true;
+    handleInsertPointerEnter(target);
+  };
+
+  const handleInsertClick = (event: MouseEvent<Element>, target: Exclude<InsertTarget, null>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    isPressingInsertRef.current = false;
+    activeInsertKeyRef.current = null;
+    insert(target);
+    tableHandles.unfreezeHandles();
+  };
+  return createPortal(
+    <>
+      <div
+        className={styles.selectionLayer}
+        contentEditable={false}
+        data-inserting={activeTargetKey ? 'true' : undefined}
+      >
+        {rowRails.map(({ key, target, top, height }) => (
+          <button
+            key={key}
+            type="button"
+            className={styles.selectionRail}
+            data-orientation="row"
+            data-selected={selectedRailKeys.has(getSelectionTargetKey(target)) ? 'true' : undefined}
+            style={
+              {
+                left: tableLeft,
+                top,
+                height,
+                '--selection-highlight-width': `${tableWidth}px`,
+              } as CSSProperties
+            }
+            aria-label={`选择第 ${target.index + 1} 行`}
+            onPointerDown={(event) => handleSelectionPointerDown(event, target)}
+            onPointerEnter={() => handleSelectionPointerEnter(target)}
+            onPointerLeave={() => handleSelectionPointerLeave(target)}
+            onClick={(event) => handleSelectionClick(event, target)}
+          />
+        ))}
+        {columnRails.map(({ key, target, left, width }) => (
+          <button
+            key={key}
+            type="button"
+            className={styles.selectionRail}
+            data-orientation="column"
+            data-selected={selectedRailKeys.has(getSelectionTargetKey(target)) ? 'true' : undefined}
+            style={
+              {
+                left,
+                top: tableTop,
+                width,
+                '--selection-highlight-height': `${tableHeight}px`,
+              } as CSSProperties
+            }
+            aria-label={`选择第 ${target.index + 1} 列`}
+            onPointerDown={(event) => handleSelectionPointerDown(event, target)}
+            onPointerEnter={() => handleSelectionPointerEnter(target)}
+            onPointerLeave={() => handleSelectionPointerLeave(target)}
+            onClick={(event) => handleSelectionClick(event, target)}
+          />
+        ))}
+      </div>
+      <div className={styles.insertLayer} contentEditable={false}>
+        {rowBoundaries.map(({ key, top, target }) => {
+          const isActive = activeTargetKey === getTargetKey(target);
+
+          return (
+            <div
+              key={key}
+              className={styles.insertHandle}
+              data-orientation="row"
+              data-active={isActive ? 'true' : undefined}
+              style={
+                {
+                  left: 0,
+                  top,
+                  width: tableRight,
+                  '--table-edge': `${tableLeft}px`,
+                } as CSSProperties
+              }
+            >
+              <Tooltip>
+                <Tooltip.Trigger className={styles.insertButtonTrigger}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    className={styles.insertButton}
+                    aria-label="插入行"
+                    onPointerEnter={() => handleInsertPointerEnter(target)}
+                    onPointerLeave={() => handleInsertPointerLeave(target)}
+                    onPointerDown={(event) => handleInsertPointerDown(event, target)}
+                    onClick={(event) => handleInsertClick(event, target)}
+                  >
+                    <Plus size={16} strokeWidth={2.25} aria-hidden="true" />
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content showArrow placement="left" offset={8}>
+                  <Tooltip.Arrow />
+                  插入行
+                </Tooltip.Content>
+              </Tooltip>
+            </div>
+          );
+        })}
+        {columnBoundaries.map(({ key, left, target }) => {
+          const isActive = activeTargetKey === getTargetKey(target);
+
+          return (
+            <div
+              key={key}
+              className={styles.insertHandle}
+              data-orientation="column"
+              data-active={isActive ? 'true' : undefined}
+              style={
+                {
+                  left,
+                  top: 0,
+                  height: tableBottom,
+                  '--table-edge': `${tableTop}px`,
+                } as CSSProperties
+              }
+            >
+              <Tooltip>
+                <Tooltip.Trigger className={styles.insertButtonTrigger}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    className={styles.insertButton}
+                    aria-label="插入列"
+                    onPointerEnter={() => handleInsertPointerEnter(target)}
+                    onPointerLeave={() => handleInsertPointerLeave(target)}
+                    onPointerDown={(event) => handleInsertPointerDown(event, target)}
+                    onClick={(event) => handleInsertClick(event, target)}
+                  >
+                    <Plus size={16} strokeWidth={2.25} aria-hidden="true" />
+                  </Button>
+                </Tooltip.Trigger>
+                <Tooltip.Content showArrow placement="top" offset={8}>
+                  <Tooltip.Arrow />
+                  插入列
+                </Tooltip.Content>
+              </Tooltip>
+            </div>
+          );
+        })}
+      </div>
+    </>,
+    portalContainer
+  );
+}
+
+export default function NoteTableHandles() {
+  const readOnly = useNoteEditorReadOnlyContext();
+  const viewReady = useEditorViewReady();
+
+  if (readOnly || !viewReady) {
+    return null;
+  }
+
+  return (
+    <div className={styles.host}>
+      <TableHandlesController
+        tableHandle={() => null}
+        tableCellHandle={NoteTableCellHandle}
+        extendButton={() => null}
+      />
+      <TableInsertHandles />
+    </div>
+  );
+}

--- a/src/components/Note/NoteTableHandles/railSelectionState.ts
+++ b/src/components/Note/NoteTableHandles/railSelectionState.ts
@@ -1,0 +1,84 @@
+import { useSyncExternalStore } from 'react';
+
+export type TableRailSelectionOrientation = 'row' | 'column';
+
+export type TableRailSelectionRect = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+type TableRailSelectionSnapshot = {
+  blockId: string | null;
+  endIndex: number | null;
+  orientation: TableRailSelectionOrientation | null;
+  rect: TableRailSelectionRect | null;
+  startIndex: number | null;
+};
+
+const listeners = new Set<() => void>();
+let snapshot: TableRailSelectionSnapshot = {
+  blockId: null,
+  endIndex: null,
+  orientation: null,
+  rect: null,
+  startIndex: null,
+};
+
+const emit = () => {
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+export const tableRailSelectionState = {
+  clear() {
+    if (snapshot.orientation === null) {
+      return;
+    }
+    snapshot = {
+      blockId: null,
+      endIndex: null,
+      orientation: null,
+      rect: null,
+      startIndex: null,
+    };
+    emit();
+  },
+  getSnapshot() {
+    return snapshot;
+  },
+  setSelection(
+    orientation: TableRailSelectionOrientation,
+    rect: TableRailSelectionRect,
+    range: { blockId: string; endIndex: number; startIndex: number }
+  ) {
+    if (
+      snapshot.blockId === range.blockId &&
+      snapshot.endIndex === range.endIndex &&
+      snapshot.orientation === orientation &&
+      snapshot.rect?.x === rect.x &&
+      snapshot.rect.y === rect.y &&
+      snapshot.rect.width === rect.width &&
+      snapshot.rect.height === rect.height &&
+      snapshot.startIndex === range.startIndex
+    ) {
+      return;
+    }
+    snapshot = { orientation, rect, ...range };
+    emit();
+  },
+  subscribe(listener: () => void) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+};
+
+export function useTableRailSelectionState() {
+  return useSyncExternalStore(
+    tableRailSelectionState.subscribe,
+    tableRailSelectionState.getSnapshot,
+    tableRailSelectionState.getSnapshot
+  );
+}

--- a/src/components/Note/NoteTableHandles/style.module.less
+++ b/src/components/Note/NoteTableHandles/style.module.less
@@ -1,0 +1,285 @@
+.host {
+  display: contents;
+}
+
+:global(.bn-editor .bn-block-content[data-content-type='table']) {
+  --note-table-insert-gutter: var(--control-height-sm);
+  --note-table-insert-size: var(--control-height-sm);
+  --note-table-insert-hit-size: var(--note-table-insert-size);
+  --note-table-insert-hit-offset: calc(
+    (var(--note-table-insert-hit-size) - var(--note-table-insert-size)) / 2
+  );
+  --note-table-insert-active-size: calc(var(--control-height-sm) - var(--space-2xs));
+  --note-table-insert-dot-size: calc(var(--space-xs) - var(--space-2xs));
+  --note-table-insert-icon-size: calc(var(--space-sm) + var(--space-2xs));
+  --note-table-insert-line-width: calc(var(--line-width) * 2);
+  --note-table-insert-outset: var(--space-sm);
+  --note-table-select-rail-size: var(--space-sm);
+  --note-table-select-hit-size: var(--control-height-sm);
+
+  position: relative;
+  overflow: visible;
+}
+
+.host :global(.bn-table-cell-handle) {
+  border: 1px solid var(--border-light);
+  background: var(--overlay);
+  color: var(--muted);
+  box-shadow: var(--surface-shadow);
+}
+
+.host :global(.bn-table-cell-handle:hover),
+.host :global(.bn-table-cell-handle[data-hovered]) {
+  background: var(--surface-secondary);
+  color: var(--surface-secondary-foreground);
+}
+
+.host :global(.bn-table-cell-handle) {
+  min-width: calc(var(--control-height-sm) + var(--space-2xs));
+  min-height: var(--control-height-sm);
+  border-radius: var(--radius-md);
+}
+
+.tableCellHandleIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.tableCellHandleIcon {
+  gap: calc(var(--space-2xs) / 2);
+}
+
+.tableCellHandleIcon svg:first-child {
+  color: var(--success);
+}
+
+.selectionLayer {
+  position: absolute;
+  inset: 0;
+  z-index: var(--note-table-selection-layer, 25);
+  overflow: visible;
+  pointer-events: none;
+}
+
+.selectionLayer[data-inserting='true'] .selectionRail {
+  pointer-events: none;
+}
+
+.selectionRail {
+  position: absolute;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.selectionRail::before,
+.selectionRail::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.selectionRail::before {
+  border-radius: var(--radius-sm);
+  background: var(--surface-secondary);
+}
+
+.selectionRail::after {
+  opacity: 0;
+  background: color-mix(in srgb, var(--primary) 14%, transparent);
+}
+
+.selectionRail:hover::before,
+.selectionRail[data-hovered]::before,
+.selectionRail[data-selected='true']::before {
+  background: var(--primary);
+}
+
+.selectionRail:hover::after,
+.selectionRail[data-hovered]::after,
+.selectionRail[data-selected='true']::after {
+  opacity: 1;
+}
+
+.selectionRail[data-orientation='row'] {
+  width: var(--note-table-select-hit-size);
+  transform: translateX(calc(-1 * var(--note-table-select-hit-size)));
+}
+
+.selectionRail[data-orientation='row']::before {
+  right: 0;
+  top: 0;
+  width: var(--note-table-select-rail-size);
+  height: 100%;
+}
+
+.selectionRail[data-orientation='row']::after {
+  left: var(--note-table-select-hit-size);
+  top: 0;
+  width: var(--selection-highlight-width);
+  height: 100%;
+}
+
+.selectionRail[data-orientation='row'][data-selected='true']::after {
+  box-shadow: inset var(--space-2xs) 0 0 var(--primary);
+}
+
+.selectionRail[data-orientation='column'] {
+  height: var(--note-table-select-hit-size);
+  transform: translateY(calc(-1 * var(--note-table-select-hit-size)));
+}
+
+.selectionRail[data-orientation='column']::before {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: var(--note-table-select-rail-size);
+}
+
+.selectionRail[data-orientation='column']::after {
+  left: 0;
+  top: calc(var(--note-table-select-hit-size) + var(--selection-highlight-offset-y, 0px));
+  width: 100%;
+  height: var(--selection-highlight-height);
+}
+
+.selectionRail[data-orientation='column'][data-selected='true']::after {
+  box-shadow: inset 0 var(--space-2xs) 0 var(--primary);
+}
+
+.insertLayer {
+  position: absolute;
+  inset: 0;
+  z-index: var(--note-table-insert-layer, 30);
+  overflow: visible;
+  pointer-events: none;
+}
+
+.insertHandle {
+  position: absolute;
+  height: var(--space-lg);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.insertHandle::before {
+  content: '';
+  position: absolute;
+  left: var(--table-edge, 0);
+  right: 0;
+  top: 50%;
+  height: var(--note-table-insert-line-width);
+  background: var(--primary);
+  opacity: 0;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.insertButtonTrigger {
+  position: absolute;
+  left: calc(
+    var(--table-edge, 0px) - var(--note-table-insert-size) - var(--note-table-insert-outset) -
+      var(--note-table-insert-hit-offset)
+  );
+  top: 50%;
+  width: var(--note-table-insert-hit-size);
+  height: var(--note-table-insert-hit-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform: translateY(-50%);
+  pointer-events: auto;
+}
+
+.insertButton {
+  width: 100%;
+  min-width: 100%;
+  height: 100%;
+  min-height: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-xl);
+  background: transparent;
+  color: var(--primary-foreground);
+  cursor: pointer;
+}
+
+.insertButton::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: var(--note-table-insert-dot-size);
+  height: var(--note-table-insert-dot-size);
+  border-radius: var(--radius-xl);
+  background: var(--muted);
+  transform: translate(-50%, -50%);
+  transition:
+    width var(--motion-duration-fast),
+    height var(--motion-duration-fast),
+    background-color var(--motion-duration-fast);
+}
+
+.insertButton svg {
+  position: relative;
+  z-index: 1;
+  width: var(--note-table-insert-icon-size);
+  height: var(--note-table-insert-icon-size);
+  color: var(--primary-foreground);
+  opacity: 0;
+  stroke: currentColor;
+}
+
+.insertHandle[data-active='true']::before {
+  opacity: 1;
+}
+
+.insertHandle[data-active='true'] .insertButton {
+  color: var(--primary-foreground);
+}
+
+.insertHandle[data-active='true'] .insertButton::before {
+  width: var(--note-table-insert-active-size);
+  height: var(--note-table-insert-active-size);
+  background: var(--primary);
+  box-shadow: var(--surface-shadow);
+}
+
+.insertHandle[data-active='true'] .insertButton svg {
+  opacity: 1;
+}
+
+.insertHandle[data-orientation='column'] {
+  width: var(--space-lg);
+  transform: translateX(-50%);
+}
+
+.insertHandle[data-orientation='column']::before {
+  left: 50%;
+  right: auto;
+  top: var(--table-edge, 0);
+  bottom: 0;
+  width: var(--note-table-insert-line-width);
+  height: auto;
+  transform: translateX(-50%);
+}
+
+.insertHandle[data-orientation='column'] .insertButton {
+  left: auto;
+  top: auto;
+  transform: none;
+}
+
+.insertHandle[data-orientation='column'] .insertButtonTrigger {
+  left: 50%;
+  top: calc(
+    var(--table-edge, 0px) - var(--note-table-insert-size) - var(--note-table-insert-outset) -
+      var(--note-table-insert-hit-offset)
+  );
+  transform: translateX(-50%);
+}

--- a/src/components/Note/NoteToolbar/components/BlockTypeMenu.tsx
+++ b/src/components/Note/NoteToolbar/components/BlockTypeMenu.tsx
@@ -1,0 +1,303 @@
+import {
+  blockNoteSchema,
+  type CustomBlockNoteEditor,
+} from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { editorHasBlockWithType } from '@blocknote/core';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { Button, Dropdown } from '@heroui/react';
+import {
+  Braces,
+  Check,
+  CheckSquare,
+  ChevronDown,
+  Heading,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  List,
+  ListOrdered,
+  ListTree,
+  TextQuote,
+  Type,
+  type LucideIcon,
+} from 'lucide-react';
+import styles from '../style.module.less';
+import {
+  cx,
+  getSelectedBlocks,
+  isRecord,
+  stopToolbarMouseDown,
+  toBlockUpdate,
+  type NoteBlock,
+} from '../utils';
+import type { ButtonGroupChildProps } from './ToolbarButton';
+
+type BlockTypeProps = Record<string, boolean | number | string>;
+
+interface BlockTypeMenuItem {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  type: string;
+  props?: BlockTypeProps;
+}
+
+const primaryBlockTypeItems: BlockTypeMenuItem[] = [
+  { key: 'paragraph', label: '正文', icon: Type, type: 'paragraph' },
+  {
+    key: 'heading-1',
+    label: '一级标题',
+    icon: Heading1,
+    type: 'heading',
+    props: { level: 1, isToggleable: false },
+  },
+  {
+    key: 'heading-2',
+    label: '二级标题',
+    icon: Heading2,
+    type: 'heading',
+    props: { level: 2, isToggleable: false },
+  },
+  {
+    key: 'heading-3',
+    label: '三级标题',
+    icon: Heading3,
+    type: 'heading',
+    props: { level: 3, isToggleable: false },
+  },
+  { key: 'numbered-list', label: '有序列表', icon: ListOrdered, type: 'numberedListItem' },
+  { key: 'bullet-list', label: '无序列表', icon: List, type: 'bulletListItem' },
+  { key: 'check-list', label: '任务', icon: CheckSquare, type: 'checkListItem' },
+  { key: 'code-block', label: '代码块', icon: Braces, type: 'codeBlock' },
+  { key: 'quote', label: '引用', icon: TextQuote, type: 'quote' },
+  { key: 'toggle-list', label: '折叠列表', icon: ListTree, type: 'toggleListItem' },
+];
+
+const moreHeadingItems: BlockTypeMenuItem[] = [
+  {
+    key: 'heading-4',
+    label: '四级标题',
+    icon: Heading4,
+    type: 'heading',
+    props: { level: 4, isToggleable: false },
+  },
+  {
+    key: 'heading-5',
+    label: '五级标题',
+    icon: Heading5,
+    type: 'heading',
+    props: { level: 5, isToggleable: false },
+  },
+  {
+    key: 'heading-6',
+    label: '六级标题',
+    icon: Heading6,
+    type: 'heading',
+    props: { level: 6, isToggleable: false },
+  },
+  {
+    key: 'toggle-heading-1',
+    label: '可折叠一级标题',
+    icon: Heading1,
+    type: 'heading',
+    props: { level: 1, isToggleable: true },
+  },
+  {
+    key: 'toggle-heading-2',
+    label: '可折叠二级标题',
+    icon: Heading2,
+    type: 'heading',
+    props: { level: 2, isToggleable: true },
+  },
+  {
+    key: 'toggle-heading-3',
+    label: '可折叠三级标题',
+    icon: Heading3,
+    type: 'heading',
+    props: { level: 3, isToggleable: true },
+  },
+];
+
+function toPropTypeMap(props?: BlockTypeProps) {
+  if (!props) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(props).map(([key, value]) => [key, typeof value])
+  ) as Record<string, 'boolean' | 'number' | 'string'>;
+}
+
+function isBlockTypeItemAvailable(editor: CustomBlockNoteEditor, item: BlockTypeMenuItem) {
+  const propTypes = toPropTypeMap(item.props);
+  return propTypes
+    ? editorHasBlockWithType(editor, item.type, propTypes)
+    : editorHasBlockWithType(editor, item.type);
+}
+
+function blockMatchesItem(block: NoteBlock | undefined, item: BlockTypeMenuItem): boolean {
+  if (!block || block.type !== item.type) {
+    return false;
+  }
+  const props = isRecord(block.props) ? block.props : {};
+  return Object.entries(item.props ?? {}).every(([key, value]) => props[key] === value);
+}
+
+function BlockTypeDropdownItem({
+  item,
+  isSelected,
+}: {
+  item: BlockTypeMenuItem;
+  isSelected: boolean;
+}) {
+  const Icon = item.icon;
+  return (
+    <Dropdown.Item id={item.key} textValue={item.label} className={styles.blockTypeMenuItem}>
+      <span className={styles.blockTypeMenuIcon}>
+        <Icon size={20} aria-hidden="true" />
+      </span>
+      <span className={styles.blockTypeMenuLabel}>{item.label}</span>
+      <span className={styles.blockTypeMenuCheck} aria-hidden="true">
+        {isSelected ? <Check size={16} /> : null}
+      </span>
+    </Dropdown.Item>
+  );
+}
+
+export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return undefined;
+      }
+      const selectedBlocks = getSelectedBlocks(editor);
+      const firstBlock = selectedBlocks[0];
+      const primaryItems = primaryBlockTypeItems.filter((item) =>
+        isBlockTypeItemAvailable(editor, item)
+      );
+      const headingItems = moreHeadingItems.filter((item) =>
+        isBlockTypeItemAvailable(editor, item)
+      );
+      const selectedItem = [...primaryItems, ...headingItems].find((item) =>
+        blockMatchesItem(firstBlock, item)
+      );
+      return { selectedBlocks, primaryItems, headingItems, selectedItem };
+    },
+  });
+
+  if (!state || !state.selectedItem) {
+    return null;
+  }
+
+  const selectedItem = state.selectedItem;
+  const selectedInMoreHeading = state.headingItems.some((item) => item.key === selectedItem.key);
+  const SelectedIcon = selectedItem.icon;
+  const itemMap = new Map(
+    [...state.primaryItems, ...state.headingItems].map((item) => [item.key, item])
+  );
+
+  const applyBlockType = (key: string) => {
+    const item = itemMap.get(key);
+    if (!item) {
+      return;
+    }
+    editor.focus();
+    editor.transact(() => {
+      for (const block of state.selectedBlocks) {
+        editor.updateBlock(
+          block,
+          toBlockUpdate({
+            type: item.type,
+            props: item.props,
+          })
+        );
+      }
+    });
+  };
+
+  return (
+    <Dropdown>
+      <Dropdown.Trigger>
+        <Button
+          {...buttonGroupProps}
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          className={styles.blockTypeTrigger}
+          onMouseDown={stopToolbarMouseDown}
+          aria-label="块类型"
+        >
+          <span className={styles.blockTypeTriggerIcon}>
+            <SelectedIcon size={21} aria-hidden="true" />
+          </span>
+          <ChevronDown size={16} aria-hidden="true" />
+        </Button>
+      </Dropdown.Trigger>
+      <Dropdown.Popover className={styles.blockTypeMenuPopover} placement="bottom start">
+        <Dropdown.Menu
+          aria-label="块类型"
+          className={styles.blockTypeMenu}
+          selectionMode="single"
+          selectedKeys={selectedInMoreHeading ? [] : [selectedItem.key]}
+          onAction={(key) => applyBlockType(String(key))}
+        >
+          {state.primaryItems.slice(0, 4).map((item) => (
+            <BlockTypeDropdownItem
+              key={item.key}
+              item={item}
+              isSelected={selectedItem.key === item.key}
+            />
+          ))}
+
+          {state.headingItems.length > 0 ? (
+            <Dropdown.SubmenuTrigger>
+              <Dropdown.Item
+                id="more-headings"
+                textValue="其他标题"
+                className={cx(
+                  styles.blockTypeMenuItem,
+                  selectedInMoreHeading && styles.blockTypeMenuItemActive
+                )}
+              >
+                <span className={styles.blockTypeMenuIcon}>
+                  <Heading size={20} aria-hidden="true" />
+                </span>
+                <span className={styles.blockTypeMenuLabel}>其他标题</span>
+                <Dropdown.SubmenuIndicator className={styles.blockTypeMenuCheck} />
+              </Dropdown.Item>
+              <Dropdown.Popover className={styles.blockTypeMenuPopover} placement="right top">
+                <Dropdown.Menu
+                  aria-label="其他标题"
+                  className={styles.blockTypeMenu}
+                  selectionMode="single"
+                  selectedKeys={selectedInMoreHeading ? [selectedItem.key] : []}
+                  onAction={(key) => applyBlockType(String(key))}
+                >
+                  {state.headingItems.map((item) => (
+                    <BlockTypeDropdownItem
+                      key={item.key}
+                      item={item}
+                      isSelected={selectedItem.key === item.key}
+                    />
+                  ))}
+                </Dropdown.Menu>
+              </Dropdown.Popover>
+            </Dropdown.SubmenuTrigger>
+          ) : null}
+
+          {state.primaryItems.slice(4).map((item) => (
+            <BlockTypeDropdownItem
+              key={item.key}
+              item={item}
+              isSelected={selectedItem.key === item.key}
+            />
+          ))}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/BlockTypeMenu.tsx
+++ b/src/components/Note/NoteToolbar/components/BlockTypeMenu.tsx
@@ -1,149 +1,17 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
 import {
-  blockNoteSchema,
-  type CustomBlockNoteEditor,
-} from '@/components/Note/CustomBlockNote/blockNoteSchema';
-import { editorHasBlockWithType } from '@blocknote/core';
+  applyBlockTypeToBlocks,
+  blockMatchesBlockTypeItem,
+  getAvailableBlockTypeItems,
+  type BlockTypeMenuItem,
+} from '@/components/Note/NoteEditorMenus/blockTypes';
 import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
 import { Button, Dropdown } from '@heroui/react';
-import {
-  Braces,
-  Check,
-  CheckSquare,
-  ChevronDown,
-  Heading,
-  Heading1,
-  Heading2,
-  Heading3,
-  Heading4,
-  Heading5,
-  Heading6,
-  List,
-  ListOrdered,
-  ListTree,
-  TextQuote,
-  Type,
-  type LucideIcon,
-} from 'lucide-react';
+import clsx from 'clsx';
+import { Check, ChevronDown, Heading } from 'lucide-react';
 import styles from '../style.module.less';
-import {
-  cx,
-  getSelectedBlocks,
-  isRecord,
-  stopToolbarMouseDown,
-  toBlockUpdate,
-  type NoteBlock,
-} from '../utils';
+import { getSelectedBlocks, stopToolbarMouseDown } from '../utils';
 import type { ButtonGroupChildProps } from './ToolbarButton';
-
-type BlockTypeProps = Record<string, boolean | number | string>;
-
-interface BlockTypeMenuItem {
-  key: string;
-  label: string;
-  icon: LucideIcon;
-  type: string;
-  props?: BlockTypeProps;
-}
-
-const primaryBlockTypeItems: BlockTypeMenuItem[] = [
-  { key: 'paragraph', label: '正文', icon: Type, type: 'paragraph' },
-  {
-    key: 'heading-1',
-    label: '一级标题',
-    icon: Heading1,
-    type: 'heading',
-    props: { level: 1, isToggleable: false },
-  },
-  {
-    key: 'heading-2',
-    label: '二级标题',
-    icon: Heading2,
-    type: 'heading',
-    props: { level: 2, isToggleable: false },
-  },
-  {
-    key: 'heading-3',
-    label: '三级标题',
-    icon: Heading3,
-    type: 'heading',
-    props: { level: 3, isToggleable: false },
-  },
-  { key: 'numbered-list', label: '有序列表', icon: ListOrdered, type: 'numberedListItem' },
-  { key: 'bullet-list', label: '无序列表', icon: List, type: 'bulletListItem' },
-  { key: 'check-list', label: '任务', icon: CheckSquare, type: 'checkListItem' },
-  { key: 'code-block', label: '代码块', icon: Braces, type: 'codeBlock' },
-  { key: 'quote', label: '引用', icon: TextQuote, type: 'quote' },
-  { key: 'toggle-list', label: '折叠列表', icon: ListTree, type: 'toggleListItem' },
-];
-
-const moreHeadingItems: BlockTypeMenuItem[] = [
-  {
-    key: 'heading-4',
-    label: '四级标题',
-    icon: Heading4,
-    type: 'heading',
-    props: { level: 4, isToggleable: false },
-  },
-  {
-    key: 'heading-5',
-    label: '五级标题',
-    icon: Heading5,
-    type: 'heading',
-    props: { level: 5, isToggleable: false },
-  },
-  {
-    key: 'heading-6',
-    label: '六级标题',
-    icon: Heading6,
-    type: 'heading',
-    props: { level: 6, isToggleable: false },
-  },
-  {
-    key: 'toggle-heading-1',
-    label: '可折叠一级标题',
-    icon: Heading1,
-    type: 'heading',
-    props: { level: 1, isToggleable: true },
-  },
-  {
-    key: 'toggle-heading-2',
-    label: '可折叠二级标题',
-    icon: Heading2,
-    type: 'heading',
-    props: { level: 2, isToggleable: true },
-  },
-  {
-    key: 'toggle-heading-3',
-    label: '可折叠三级标题',
-    icon: Heading3,
-    type: 'heading',
-    props: { level: 3, isToggleable: true },
-  },
-];
-
-function toPropTypeMap(props?: BlockTypeProps) {
-  if (!props) {
-    return undefined;
-  }
-  return Object.fromEntries(
-    Object.entries(props).map(([key, value]) => [key, typeof value])
-  ) as Record<string, 'boolean' | 'number' | 'string'>;
-}
-
-function isBlockTypeItemAvailable(editor: CustomBlockNoteEditor, item: BlockTypeMenuItem) {
-  const propTypes = toPropTypeMap(item.props);
-  return propTypes
-    ? editorHasBlockWithType(editor, item.type, propTypes)
-    : editorHasBlockWithType(editor, item.type);
-}
-
-function blockMatchesItem(block: NoteBlock | undefined, item: BlockTypeMenuItem): boolean {
-  if (!block || block.type !== item.type) {
-    return false;
-  }
-  const props = isRecord(block.props) ? block.props : {};
-  return Object.entries(item.props ?? {}).every(([key, value]) => props[key] === value);
-}
 
 function BlockTypeDropdownItem({
   item,
@@ -176,16 +44,11 @@ export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
       }
       const selectedBlocks = getSelectedBlocks(editor);
       const firstBlock = selectedBlocks[0];
-      const primaryItems = primaryBlockTypeItems.filter((item) =>
-        isBlockTypeItemAvailable(editor, item)
-      );
-      const headingItems = moreHeadingItems.filter((item) =>
-        isBlockTypeItemAvailable(editor, item)
-      );
+      const { primaryItems, headingItems, allItems } = getAvailableBlockTypeItems(editor);
       const selectedItem = [...primaryItems, ...headingItems].find((item) =>
-        blockMatchesItem(firstBlock, item)
+        blockMatchesBlockTypeItem(firstBlock, item)
       );
-      return { selectedBlocks, primaryItems, headingItems, selectedItem };
+      return { selectedBlocks, primaryItems, headingItems, allItems, selectedItem };
     },
   });
 
@@ -196,9 +59,7 @@ export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
   const selectedItem = state.selectedItem;
   const selectedInMoreHeading = state.headingItems.some((item) => item.key === selectedItem.key);
   const SelectedIcon = selectedItem.icon;
-  const itemMap = new Map(
-    [...state.primaryItems, ...state.headingItems].map((item) => [item.key, item])
-  );
+  const itemMap = new Map(state.allItems.map((item) => [item.key, item]));
 
   const applyBlockType = (key: string) => {
     const item = itemMap.get(key);
@@ -206,17 +67,7 @@ export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
       return;
     }
     editor.focus();
-    editor.transact(() => {
-      for (const block of state.selectedBlocks) {
-        editor.updateBlock(
-          block,
-          toBlockUpdate({
-            type: item.type,
-            props: item.props,
-          })
-        );
-      }
-    });
+    applyBlockTypeToBlocks(editor, state.selectedBlocks, item);
   };
 
   return (
@@ -232,7 +83,7 @@ export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
           aria-label="块类型"
         >
           <span className={styles.blockTypeTriggerIcon}>
-            <SelectedIcon size={21} aria-hidden="true" />
+            <SelectedIcon size={20} aria-hidden="true" />
           </span>
           <ChevronDown size={16} aria-hidden="true" />
         </Button>
@@ -258,7 +109,7 @@ export function BlockTypeMenu(buttonGroupProps: ButtonGroupChildProps) {
               <Dropdown.Item
                 id="more-headings"
                 textValue="其他标题"
-                className={cx(
+                className={clsx(
                   styles.blockTypeMenuItem,
                   selectedInMoreHeading && styles.blockTypeMenuItemActive
                 )}

--- a/src/components/Note/NoteToolbar/components/ColorMenu.tsx
+++ b/src/components/Note/NoteToolbar/components/ColorMenu.tsx
@@ -1,0 +1,274 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { Popover } from '@/components/Overlay';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { Button, ColorSwatchPicker } from '@heroui/react';
+import { Baseline, ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import styles from '../style.module.less';
+import {
+  blockHasInlineContent,
+  colorStyleExists,
+  cx,
+  getSelectedBlocks,
+  stopToolbarMouseDown,
+  toStyleUpdate,
+} from '../utils';
+import type { ButtonGroupChildProps } from './ToolbarButton';
+
+type ColorKey =
+  'default' | 'gray' | 'brown' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink';
+
+interface ColorItem {
+  key: ColorKey;
+  label: string;
+  value: string;
+  textClassName: string;
+  backgroundClassName: string;
+}
+
+const colorItems: ColorItem[] = [
+  {
+    key: 'default',
+    label: '默认',
+    value: '#111827',
+    textClassName: styles.textDefault,
+    backgroundClassName: styles.backgroundDefault,
+  },
+  {
+    key: 'gray',
+    label: '灰色',
+    value: '#8a8f98',
+    textClassName: styles.textGray,
+    backgroundClassName: styles.backgroundGray,
+  },
+  {
+    key: 'brown',
+    label: '棕色',
+    value: '#8b5e3c',
+    textClassName: styles.textBrown,
+    backgroundClassName: styles.backgroundBrown,
+  },
+  {
+    key: 'red',
+    label: '红色',
+    value: '#ef4444',
+    textClassName: styles.textRed,
+    backgroundClassName: styles.backgroundRed,
+  },
+  {
+    key: 'orange',
+    label: '橙色',
+    value: '#f97316',
+    textClassName: styles.textOrange,
+    backgroundClassName: styles.backgroundOrange,
+  },
+  {
+    key: 'yellow',
+    label: '黄色',
+    value: '#eab308',
+    textClassName: styles.textYellow,
+    backgroundClassName: styles.backgroundYellow,
+  },
+  {
+    key: 'green',
+    label: '绿色',
+    value: '#22c55e',
+    textClassName: styles.textGreen,
+    backgroundClassName: styles.backgroundGreen,
+  },
+  {
+    key: 'blue',
+    label: '蓝色',
+    value: '#3b82f6',
+    textClassName: styles.textBlue,
+    backgroundClassName: styles.backgroundBlue,
+  },
+  {
+    key: 'purple',
+    label: '紫色',
+    value: '#7c3aed',
+    textClassName: styles.textPurple,
+    backgroundClassName: styles.backgroundPurple,
+  },
+  {
+    key: 'pink',
+    label: '粉色',
+    value: '#ec4899',
+    textClassName: styles.textPink,
+    backgroundClassName: styles.backgroundPink,
+  },
+];
+
+function normalizeColor(color: string | undefined): ColorKey {
+  const value = color ?? 'default';
+  return colorItems.some((item) => item.key === value) ? (value as ColorKey) : 'default';
+}
+
+function getColorItem(color: string | undefined) {
+  const safeColor = normalizeColor(color);
+  return colorItems.find((item) => item.key === safeColor) ?? colorItems[0];
+}
+
+function findColorItemByPickerValue(value: string) {
+  const normalizedValue = value.toLowerCase();
+  return colorItems.find((item) => item.value.toLowerCase() === normalizedValue);
+}
+
+function ColorSection({
+  title,
+  selectedColor,
+  mode,
+  onSelect,
+}: {
+  title: string;
+  selectedColor?: string;
+  mode: 'text' | 'background';
+  onSelect: (color: ColorKey) => void;
+}) {
+  const selectedItem = getColorItem(selectedColor);
+
+  return (
+    <div className={styles.colorSection}>
+      <div className={styles.colorSectionTitle}>{title}</div>
+      <ColorSwatchPicker
+        aria-label={title}
+        className={styles.colorSwatchPicker}
+        layout="grid"
+        value={selectedItem.value}
+        onChange={(color) => {
+          const item = findColorItemByPickerValue(color.toString('hex'));
+          if (item) {
+            onSelect(item.key);
+          }
+        }}
+      >
+        {colorItems.map((item) => (
+          <ColorSwatchPicker.Item
+            key={`${mode}-${item.key}`}
+            color={item.value}
+            aria-label={`${title}${item.label}`}
+            className={({ isSelected }) =>
+              cx(styles.colorSwatchItem, isSelected && styles.colorSwatchSelected)
+            }
+            onPress={() => onSelect(item.key)}
+          >
+            {mode === 'text' ? (
+              <Baseline
+                size={20}
+                className={cx(styles.colorTextPreview, item.textClassName)}
+                aria-hidden="true"
+              />
+            ) : (
+              <span className={cx(styles.colorBackgroundPreview, item.backgroundClassName)} />
+            )}
+          </ColorSwatchPicker.Item>
+        ))}
+      </ColorSwatchPicker>
+    </div>
+  );
+}
+
+export function ColorMenu(buttonGroupProps: ButtonGroupChildProps) {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const [open, setOpen] = useState(false);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable || !getSelectedBlocks(editor).find(blockHasInlineContent)) {
+        return undefined;
+      }
+      const hasTextColor = colorStyleExists(editor, 'textColor');
+      const hasBackgroundColor = colorStyleExists(editor, 'backgroundColor');
+      if (!hasTextColor && !hasBackgroundColor) {
+        return undefined;
+      }
+      const activeStyles = editor.getActiveStyles();
+      return {
+        textColor: hasTextColor ? String(activeStyles.textColor ?? 'default') : undefined,
+        backgroundColor: hasBackgroundColor
+          ? String(activeStyles.backgroundColor ?? 'default')
+          : undefined,
+        hasTextColor,
+        hasBackgroundColor,
+      };
+    },
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  const refocusEditor = () => {
+    window.setTimeout(() => editor.focus());
+  };
+
+  const applyColor = (target: 'textColor' | 'backgroundColor', color: ColorKey) => {
+    if (color === 'default') {
+      editor.removeStyles(toStyleUpdate({ [target]: color }));
+    } else {
+      editor.addStyles(toStyleUpdate({ [target]: color }));
+    }
+    refocusEditor();
+  };
+
+  const resetColors = () => {
+    if (state.hasTextColor) {
+      editor.removeStyles(toStyleUpdate({ textColor: 'default' }));
+    }
+    if (state.hasBackgroundColor) {
+      editor.removeStyles(toStyleUpdate({ backgroundColor: 'default' }));
+    }
+    setOpen(false);
+    refocusEditor();
+  };
+  const selectedTextColor = getColorItem(state.textColor);
+
+  return (
+    <Popover isOpen={open} onOpenChange={setOpen} deferContent={false}>
+      <Popover.Trigger>
+        <Button
+          {...buttonGroupProps}
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          className={cx(styles.colorTrigger, open && styles.toolbarButtonActive)}
+          onMouseDown={stopToolbarMouseDown}
+          aria-label="颜色"
+        >
+          <Baseline size={20} className={selectedTextColor.textClassName} aria-hidden="true" />
+          <ChevronDown size={16} aria-hidden="true" />
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content className={styles.colorPopover} placement="bottom">
+        <Popover.Dialog>
+          <div className={styles.colorPanel}>
+            {state.hasTextColor ? (
+              <ColorSection
+                title="字体颜色"
+                selectedColor={state.textColor}
+                mode="text"
+                onSelect={(color) => applyColor('textColor', color)}
+              />
+            ) : null}
+            {state.hasBackgroundColor ? (
+              <ColorSection
+                title="背景颜色"
+                selectedColor={state.backgroundColor}
+                mode="background"
+                onSelect={(color) => applyColor('backgroundColor', color)}
+              />
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              className={styles.resetColorButton}
+              onPress={resetColors}
+            >
+              恢复默认
+            </Button>
+          </div>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/ColorMenu.tsx
+++ b/src/components/Note/NoteToolbar/components/ColorMenu.tsx
@@ -1,172 +1,21 @@
 import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { ColorPaletteContent } from '@/components/Note/NoteEditorMenus/colorPalette';
+import { getColorItem, type ColorKey } from '@/components/Note/NoteEditorMenus/colorPaletteData';
 import { Popover } from '@/components/Overlay';
 import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
-import { Button, ColorSwatchPicker } from '@heroui/react';
+import { Button } from '@heroui/react';
+import clsx from 'clsx';
 import { Baseline, ChevronDown } from 'lucide-react';
 import { useState } from 'react';
 import styles from '../style.module.less';
 import {
   blockHasInlineContent,
   colorStyleExists,
-  cx,
   getSelectedBlocks,
   stopToolbarMouseDown,
   toStyleUpdate,
 } from '../utils';
 import type { ButtonGroupChildProps } from './ToolbarButton';
-
-type ColorKey =
-  'default' | 'gray' | 'brown' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink';
-
-interface ColorItem {
-  key: ColorKey;
-  label: string;
-  value: string;
-  textClassName: string;
-  backgroundClassName: string;
-}
-
-const colorItems: ColorItem[] = [
-  {
-    key: 'default',
-    label: '默认',
-    value: '#111827',
-    textClassName: styles.textDefault,
-    backgroundClassName: styles.backgroundDefault,
-  },
-  {
-    key: 'gray',
-    label: '灰色',
-    value: '#8a8f98',
-    textClassName: styles.textGray,
-    backgroundClassName: styles.backgroundGray,
-  },
-  {
-    key: 'brown',
-    label: '棕色',
-    value: '#8b5e3c',
-    textClassName: styles.textBrown,
-    backgroundClassName: styles.backgroundBrown,
-  },
-  {
-    key: 'red',
-    label: '红色',
-    value: '#ef4444',
-    textClassName: styles.textRed,
-    backgroundClassName: styles.backgroundRed,
-  },
-  {
-    key: 'orange',
-    label: '橙色',
-    value: '#f97316',
-    textClassName: styles.textOrange,
-    backgroundClassName: styles.backgroundOrange,
-  },
-  {
-    key: 'yellow',
-    label: '黄色',
-    value: '#eab308',
-    textClassName: styles.textYellow,
-    backgroundClassName: styles.backgroundYellow,
-  },
-  {
-    key: 'green',
-    label: '绿色',
-    value: '#22c55e',
-    textClassName: styles.textGreen,
-    backgroundClassName: styles.backgroundGreen,
-  },
-  {
-    key: 'blue',
-    label: '蓝色',
-    value: '#3b82f6',
-    textClassName: styles.textBlue,
-    backgroundClassName: styles.backgroundBlue,
-  },
-  {
-    key: 'purple',
-    label: '紫色',
-    value: '#7c3aed',
-    textClassName: styles.textPurple,
-    backgroundClassName: styles.backgroundPurple,
-  },
-  {
-    key: 'pink',
-    label: '粉色',
-    value: '#ec4899',
-    textClassName: styles.textPink,
-    backgroundClassName: styles.backgroundPink,
-  },
-];
-
-function normalizeColor(color: string | undefined): ColorKey {
-  const value = color ?? 'default';
-  return colorItems.some((item) => item.key === value) ? (value as ColorKey) : 'default';
-}
-
-function getColorItem(color: string | undefined) {
-  const safeColor = normalizeColor(color);
-  return colorItems.find((item) => item.key === safeColor) ?? colorItems[0];
-}
-
-function findColorItemByPickerValue(value: string) {
-  const normalizedValue = value.toLowerCase();
-  return colorItems.find((item) => item.value.toLowerCase() === normalizedValue);
-}
-
-function ColorSection({
-  title,
-  selectedColor,
-  mode,
-  onSelect,
-}: {
-  title: string;
-  selectedColor?: string;
-  mode: 'text' | 'background';
-  onSelect: (color: ColorKey) => void;
-}) {
-  const selectedItem = getColorItem(selectedColor);
-
-  return (
-    <div className={styles.colorSection}>
-      <div className={styles.colorSectionTitle}>{title}</div>
-      <ColorSwatchPicker
-        aria-label={title}
-        className={styles.colorSwatchPicker}
-        layout="grid"
-        value={selectedItem.value}
-        onChange={(color) => {
-          const item = findColorItemByPickerValue(color.toString('hex'));
-          if (item) {
-            onSelect(item.key);
-          }
-        }}
-      >
-        {colorItems.map((item) => (
-          <ColorSwatchPicker.Item
-            key={`${mode}-${item.key}`}
-            color={item.value}
-            aria-label={`${title}${item.label}`}
-            className={({ isSelected }) =>
-              cx(styles.colorSwatchItem, isSelected && styles.colorSwatchSelected)
-            }
-            onPress={() => onSelect(item.key)}
-          >
-            {mode === 'text' ? (
-              <Baseline
-                size={20}
-                className={cx(styles.colorTextPreview, item.textClassName)}
-                aria-hidden="true"
-              />
-            ) : (
-              <span className={cx(styles.colorBackgroundPreview, item.backgroundClassName)} />
-            )}
-          </ColorSwatchPicker.Item>
-        ))}
-      </ColorSwatchPicker>
-    </div>
-  );
-}
 
 export function ColorMenu(buttonGroupProps: ButtonGroupChildProps) {
   const editor = useBlockNoteEditor(blockNoteSchema);
@@ -231,7 +80,7 @@ export function ColorMenu(buttonGroupProps: ButtonGroupChildProps) {
           variant="ghost"
           size="sm"
           isIconOnly
-          className={cx(styles.colorTrigger, open && styles.toolbarButtonActive)}
+          className={clsx(styles.colorTrigger, open && styles.toolbarButtonActive)}
           onMouseDown={stopToolbarMouseDown}
           aria-label="颜色"
         >
@@ -241,32 +90,25 @@ export function ColorMenu(buttonGroupProps: ButtonGroupChildProps) {
       </Popover.Trigger>
       <Popover.Content className={styles.colorPopover} placement="bottom">
         <Popover.Dialog>
-          <div className={styles.colorPanel}>
-            {state.hasTextColor ? (
-              <ColorSection
-                title="字体颜色"
-                selectedColor={state.textColor}
-                mode="text"
-                onSelect={(color) => applyColor('textColor', color)}
-              />
-            ) : null}
-            {state.hasBackgroundColor ? (
-              <ColorSection
-                title="背景颜色"
-                selectedColor={state.backgroundColor}
-                mode="background"
-                onSelect={(color) => applyColor('backgroundColor', color)}
-              />
-            ) : null}
-            <Button
-              variant="outline"
-              size="sm"
-              className={styles.resetColorButton}
-              onPress={resetColors}
-            >
-              恢复默认
-            </Button>
-          </div>
+          <ColorPaletteContent
+            text={
+              state.hasTextColor
+                ? {
+                    color: state.textColor,
+                    onChange: (color) => applyColor('textColor', color),
+                  }
+                : undefined
+            }
+            background={
+              state.hasBackgroundColor
+                ? {
+                    color: state.backgroundColor,
+                    onChange: (color) => applyColor('backgroundColor', color),
+                  }
+                : undefined
+            }
+            onReset={resetColors}
+          />
         </Popover.Dialog>
       </Popover.Content>
     </Popover>

--- a/src/components/Note/NoteToolbar/components/FileButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/FileButtons.tsx
@@ -1,0 +1,98 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { Popover } from '@/components/Overlay';
+import { blockHasType, editorHasBlockWithType } from '@blocknote/core';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { Button, Input } from '@heroui/react';
+import { PencilLine } from 'lucide-react';
+import { useState, type KeyboardEvent } from 'react';
+import styles from '../style.module.less';
+import { getSelectedBlocks, toBlockUpdate } from '../utils';
+import { ToolbarButton, type ButtonGroupChildProps } from './ToolbarButton';
+
+export function FileCaptionToolbarButton(buttonGroupProps: ButtonGroupChildProps) {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const [caption, setCaption] = useState('');
+  const [open, setOpen] = useState(false);
+  const block = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return undefined;
+      }
+
+      const selectedBlocks = getSelectedBlocks(editor);
+      if (selectedBlocks.length !== 1) {
+        return undefined;
+      }
+
+      const selectedBlock = selectedBlocks[0];
+      if (
+        !blockHasType(selectedBlock, editor, selectedBlock.type, {
+          url: 'string',
+          caption: 'string',
+        })
+      ) {
+        return undefined;
+      }
+
+      return selectedBlock;
+    },
+  });
+
+  if (!block) {
+    return null;
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setCaption(String(block.props.caption ?? ''));
+    }
+    setOpen(nextOpen);
+  };
+
+  const saveCaption = () => {
+    if (!editorHasBlockWithType(editor, block.type, { caption: 'string' })) {
+      return;
+    }
+    editor.updateBlock(
+      block,
+      toBlockUpdate({
+        props: { caption },
+      })
+    );
+    setOpen(false);
+    window.setTimeout(() => editor.focus());
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      saveCaption();
+    }
+  };
+
+  return (
+    <Popover isOpen={open} onOpenChange={handleOpenChange} deferContent={false}>
+      <Popover.Trigger>
+        <ToolbarButton {...buttonGroupProps} label="编辑图片标题" icon={<PencilLine size={20} />} />
+      </Popover.Trigger>
+      <Popover.Content className={styles.formPopover} placement="bottom">
+        <Popover.Dialog>
+          <div className={styles.formPanel} onMouseDown={(event) => event.stopPropagation()}>
+            <Input
+              autoFocus
+              aria-label="图片标题"
+              placeholder="输入图片标题"
+              value={caption}
+              onChange={(event) => setCaption(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <Button size="sm" variant="primary" onPress={saveCaption}>
+              确定
+            </Button>
+          </div>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/LinkButton.tsx
+++ b/src/components/Note/NoteToolbar/components/LinkButton.tsx
@@ -1,0 +1,152 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { Popover } from '@/components/Overlay';
+import { isTableCellSelection } from '@blocknote/core';
+import {
+  DEFAULT_LINK_PROTOCOL,
+  FormattingToolbarExtension,
+  LinkToolbarExtension,
+  ShowSelectionExtension,
+  VALID_LINK_PROTOCOLS,
+} from '@blocknote/core/extensions';
+import { useBlockNoteEditor, useEditorState, useExtension } from '@blocknote/react';
+import { Button, Input } from '@heroui/react';
+import { useEventListener, useUnmount } from 'ahooks';
+import { Link } from 'lucide-react';
+import { useCallback, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import styles from '../style.module.less';
+import { blockHasInlineContent, getSelectedBlocks } from '../utils';
+import { ToolbarButton, type ButtonGroupChildProps } from './ToolbarButton';
+
+function normalizeUrl(url: string) {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) {
+    return trimmedUrl;
+  }
+  return VALID_LINK_PROTOCOLS.some((protocol) => trimmedUrl.startsWith(protocol))
+    ? trimmedUrl
+    : `${DEFAULT_LINK_PROTOCOL}://${trimmedUrl}`;
+}
+
+export function CreateLinkToolbarButton(buttonGroupProps: ButtonGroupChildProps) {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const formattingToolbar = useExtension(FormattingToolbarExtension);
+  const { editLink } = useExtension(LinkToolbarExtension);
+  const { showSelection } = useExtension(ShowSelectionExtension);
+  const [open, setOpen] = useState(false);
+  const [url, setUrl] = useState('');
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (
+        !editor.isEditable ||
+        !('link' in editor.schema.inlineContentSchema) ||
+        isTableCellSelection(editor.prosemirrorState.selection) ||
+        !getSelectedBlocks(editor).find(blockHasInlineContent)
+      ) {
+        return undefined;
+      }
+
+      return {
+        url: editor.getSelectedLinkUrl() ?? '',
+        text: editor.getSelectedText(),
+        range: {
+          from: editor.prosemirrorState.selection.from,
+          to: editor.prosemirrorState.selection.to,
+        },
+      };
+    },
+  });
+
+  const openLinkPopover = useCallback(() => {
+    if (!state) {
+      return;
+    }
+    setUrl(state.url);
+    showSelection(true, 'createLinkButton');
+    setOpen(true);
+  }, [showSelection, state]);
+
+  const closeLinkPopover = useCallback(() => {
+    showSelection(false, 'createLinkButton');
+    setOpen(false);
+  }, [showSelection]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        openLinkPopover();
+      } else {
+        closeLinkPopover();
+      }
+    },
+    [closeLinkPopover, openLinkPopover]
+  );
+
+  const handleEditorKeyDown = useCallback(
+    (event: Event) => {
+      if (!(event instanceof globalThis.KeyboardEvent)) {
+        return;
+      }
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        openLinkPopover();
+      }
+    },
+    [openLinkPopover]
+  );
+
+  useEventListener('keydown', handleEditorKeyDown, {
+    target: editor.domElement,
+  });
+
+  useUnmount(() => {
+    showSelection(false, 'createLinkButton');
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  const saveLink = () => {
+    const nextUrl = normalizeUrl(url);
+    if (!nextUrl) {
+      return;
+    }
+    editLink(nextUrl, state.text, state.range.from);
+    formattingToolbar.store.setState(false);
+    closeLinkPopover();
+    window.setTimeout(() => editor.focus());
+  };
+
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+      event.preventDefault();
+      saveLink();
+    }
+  };
+
+  return (
+    <Popover isOpen={open} onOpenChange={handleOpenChange} deferContent={false}>
+      <Popover.Trigger>
+        <ToolbarButton {...buttonGroupProps} label="添加链接" icon={<Link size={20} />} />
+      </Popover.Trigger>
+      <Popover.Content className={styles.formPopover} placement="bottom">
+        <Popover.Dialog>
+          <div className={styles.formPanel} onMouseDown={(event) => event.stopPropagation()}>
+            <Input
+              autoFocus
+              aria-label="链接地址"
+              placeholder="输入链接地址"
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <Button size="sm" variant="primary" onPress={saveLink}>
+              确定
+            </Button>
+          </div>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/NestButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/NestButtons.tsx
@@ -1,4 +1,5 @@
 import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { blockHasType } from '@blocknote/core';
 import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
 import { ToggleButtonGroup } from '@heroui/react';
 import { IndentDecrease, IndentIncrease } from 'lucide-react';
@@ -10,7 +11,12 @@ export function NestButton({ type }: { type: 'nest' | 'unnest' }) {
   const state = useEditorState({
     editor,
     selector: ({ editor }) => {
-      if (!editor.isEditable || !getSelectedBlocks(editor).find(blockHasInlineContent)) {
+      const selectedBlocks = getSelectedBlocks(editor);
+      if (
+        !editor.isEditable ||
+        selectedBlocks.some((block) => blockHasType(block, editor, 'table')) ||
+        !selectedBlocks.find(blockHasInlineContent)
+      ) {
         return undefined;
       }
       return type === 'nest'
@@ -45,8 +51,14 @@ export function NestButtons() {
   const editor = useBlockNoteEditor(blockNoteSchema);
   const visible = useEditorState({
     editor,
-    selector: ({ editor }) =>
-      editor.isEditable && getSelectedBlocks(editor).some(blockHasInlineContent),
+    selector: ({ editor }) => {
+      const selectedBlocks = getSelectedBlocks(editor);
+      return (
+        editor.isEditable &&
+        selectedBlocks.some(blockHasInlineContent) &&
+        !selectedBlocks.some((block) => blockHasType(block, editor, 'table'))
+      );
+    },
   });
 
   if (!visible) {

--- a/src/components/Note/NoteToolbar/components/NestButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/NestButtons.tsx
@@ -1,0 +1,69 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { ToggleButtonGroup } from '@heroui/react';
+import { IndentDecrease, IndentIncrease } from 'lucide-react';
+import { blockHasInlineContent, getSelectedBlocks } from '../utils';
+import { ToolbarToggleButton } from './ToolbarButton';
+
+export function NestButton({ type }: { type: 'nest' | 'unnest' }) {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable || !getSelectedBlocks(editor).find(blockHasInlineContent)) {
+        return undefined;
+      }
+      return type === 'nest'
+        ? { enabled: editor.canNestBlock() }
+        : { enabled: editor.canUnnestBlock() };
+    },
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  return (
+    <ToolbarToggleButton
+      id={type}
+      label={type === 'nest' ? '增加缩进' : '减少缩进'}
+      icon={type === 'nest' ? <IndentIncrease size={20} /> : <IndentDecrease size={20} />}
+      isDisabled={!state.enabled}
+      onPress={() => {
+        editor.focus();
+        if (type === 'nest') {
+          editor.nestBlock();
+        } else {
+          editor.unnestBlock();
+        }
+      }}
+    />
+  );
+}
+
+export function NestButtons() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const visible = useEditorState({
+    editor,
+    selector: ({ editor }) =>
+      editor.isEditable && getSelectedBlocks(editor).some(blockHasInlineContent),
+  });
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <ToggleButtonGroup
+      aria-label="缩进"
+      selectionMode="multiple"
+      selectedKeys={new Set()}
+      orientation="horizontal"
+      size="sm"
+    >
+      <NestButton type="nest" />
+      <ToggleButtonGroup.Separator />
+      <NestButton type="unnest" />
+    </ToggleButtonGroup>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/TableCellButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/TableCellButtons.tsx
@@ -1,0 +1,292 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { ColorPaletteContent } from '@/components/Note/NoteEditorMenus/colorPalette';
+import type { ColorKey } from '@/components/Note/NoteEditorMenus/colorPaletteData';
+import { useTableRailSelectionState } from '@/components/Note/NoteTableHandles/railSelectionState';
+import { getSafeTableCellSelection, getTableHandles } from '@/components/Note/tableHandlesSafe';
+import { Popover } from '@/components/Overlay';
+import {
+  blockHasType,
+  mapTableCell,
+  type InlineContentSchema,
+  type StyleSchema,
+  type TableContent,
+} from '@blocknote/core';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { Button, ButtonGroup, ToggleButtonGroup } from '@heroui/react';
+import { Paintbrush, PanelLeft, PanelTop, TableCellsMerge, TableCellsSplit } from 'lucide-react';
+import { Fragment, useState } from 'react';
+import styles from '../style.module.less';
+import { getSelectedBlocks, stopToolbarMouseDown, toBlockUpdate } from '../utils';
+import { ToolbarToggleButton } from './ToolbarButton';
+
+type TableCellValue = TableContent<
+  InlineContentSchema,
+  StyleSchema
+>['rows'][number]['cells'][number];
+type SelectedTableCell = { cell: TableCellValue; col: number; row: number };
+type SelectedTableCellIndices = Pick<SelectedTableCell, 'col' | 'row'>;
+
+function getCellKey(cell: { col: number; row: number }) {
+  return `${cell.row}:${cell.col}`;
+}
+
+function isMergedCell(cell: TableCellValue) {
+  const props = mapTableCell(cell).props;
+  return (props.colspan ?? 1) > 1 || (props.rowspan ?? 1) > 1;
+}
+
+export function TableCellButtons() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const railSelection = useTableRailSelectionState();
+  const [colorOpen, setColorOpen] = useState(false);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return undefined;
+      }
+      const selectedBlocks = getSelectedBlocks(editor);
+      const tableBlock = selectedBlocks.find((block) => blockHasType(block, editor, 'table'));
+      const tableHandles = getTableHandles(editor);
+      if (!tableHandles || !tableBlock) {
+        return undefined;
+      }
+      const cellSelection = getSafeTableCellSelection(editor);
+      const tableContent = tableBlock?.content as
+        TableContent<InlineContentSchema, StyleSchema> | undefined;
+      if (!tableContent) {
+        return undefined;
+      }
+
+      const selectedCells: SelectedTableCell[] = [];
+      const selectedCellKeys = new Set<string>();
+      const addCell = (cell: SelectedTableCell) => {
+        const key = getCellKey(cell);
+        if (selectedCellKeys.has(key)) {
+          return;
+        }
+        selectedCellKeys.add(key);
+        selectedCells.push(cell);
+      };
+      const railEndIndex = railSelection.endIndex;
+      const railOrientation = railSelection.orientation;
+      const railStartIndex = railSelection.startIndex;
+      const hasMatchingRailSelection =
+        railOrientation !== null &&
+        railSelection.blockId === tableBlock.id &&
+        railStartIndex !== null &&
+        railEndIndex !== null;
+
+      if (hasMatchingRailSelection) {
+        const startIndex = Math.min(railStartIndex, railEndIndex);
+        const endIndex = Math.max(railStartIndex, railEndIndex);
+        const tableBlockForHandles = tableBlock as unknown as Parameters<
+          typeof tableHandles.getCellsAtRowHandle
+        >[0];
+
+        for (let index = startIndex; index <= endIndex; index += 1) {
+          const cells =
+            railOrientation === 'row'
+              ? tableHandles.getCellsAtRowHandle(tableBlockForHandles, index)
+              : tableHandles.getCellsAtColumnHandle(tableBlockForHandles, index);
+
+          for (const cell of cells) {
+            addCell({
+              cell: cell.cell as TableCellValue,
+              col: cell.col,
+              row: cell.row,
+            });
+          }
+        }
+      } else if (cellSelection) {
+        for (const cell of cellSelection.cells) {
+          const tableCell = tableContent.rows[cell.row]?.cells[cell.col];
+          if (tableCell) {
+            addCell({ cell: tableCell, col: cell.col, row: cell.row });
+          }
+        }
+      }
+
+      const railSelectionStart = hasMatchingRailSelection
+        ? Math.min(railStartIndex, railEndIndex)
+        : null;
+      const railSelectionEnd = hasMatchingRailSelection
+        ? Math.max(railStartIndex, railEndIndex)
+        : null;
+      const mergedCells = selectedCells.filter(({ cell }) => isMergedCell(cell));
+      const canSplit = mergedCells.length > 0;
+      const canMerge = !canSplit && selectedCells.length > 1;
+      const canToggleHeaderRow =
+        railOrientation === 'row' && railSelectionStart === 0 && railSelectionEnd === 0;
+      const canToggleHeaderColumn =
+        railOrientation === 'column' && railSelectionStart === 0 && railSelectionEnd === 0;
+
+      if (!canMerge && !canSplit && !selectedCells.length) {
+        return undefined;
+      }
+
+      return {
+        backgroundColor: selectedCells[0]
+          ? mapTableCell(selectedCells[0].cell).props.backgroundColor
+          : 'default',
+        block: tableBlock,
+        canToggleHeaderColumn,
+        canToggleHeaderRow,
+        isHeaderColumn: Boolean(tableContent.headerCols),
+        isHeaderRow: Boolean(tableContent.headerRows),
+        mergeAction: canSplit ? ('split' as const) : canMerge ? ('merge' as const) : null,
+        selectedCells: selectedCells.map(({ col, row }) => ({ col, row })),
+        splitCells: mergedCells.map(({ col, row }) => ({ col, row })),
+        tableContent,
+      };
+    },
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  const tableHandles = getTableHandles(editor);
+  const isSplitAction = state.mergeAction === 'split';
+  const selectedKeys = new Set<string>([
+    ...(isSplitAction ? ['split-cell'] : []),
+    ...(state.canToggleHeaderRow && state.isHeaderRow ? ['table-header-row'] : []),
+    ...(state.canToggleHeaderColumn && state.isHeaderColumn ? ['table-header-column'] : []),
+  ]);
+  const toggleButtons: Array<'merge' | 'header-row' | 'header-column'> = [
+    ...(state.mergeAction ? (['merge'] as const) : []),
+    ...(state.canToggleHeaderRow ? (['header-row'] as const) : []),
+    ...(state.canToggleHeaderColumn ? (['header-column'] as const) : []),
+  ];
+
+  const refocusEditor = () => {
+    window.setTimeout(() => editor.focus());
+  };
+
+  const updateTableContent = (tableContent: TableContent<InlineContentSchema, StyleSchema>) => {
+    editor.updateBlock(
+      state.block,
+      toBlockUpdate({
+        type: 'table',
+        content: tableContent,
+      })
+    );
+    refocusEditor();
+  };
+
+  const toggleHeader = (target: 'column' | 'row') => {
+    updateTableContent({
+      ...state.tableContent,
+      type: 'tableContent',
+      ...(target === 'row'
+        ? { headerRows: state.isHeaderRow ? undefined : 1 }
+        : { headerCols: state.isHeaderColumn ? undefined : 1 }),
+    });
+  };
+
+  const applyBackgroundColor = (color: ColorKey) => {
+    const rows = state.tableContent.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => mapTableCell(cell)),
+    }));
+    for (const cell of state.selectedCells as SelectedTableCellIndices[]) {
+      const targetCell = rows[cell.row]?.cells[cell.col];
+      if (targetCell) {
+        targetCell.props.backgroundColor = color;
+      }
+    }
+    updateTableContent({
+      ...state.tableContent,
+      type: 'tableContent',
+      rows,
+    });
+  };
+
+  return (
+    <>
+      {toggleButtons.length ? (
+        <ToggleButtonGroup
+          aria-label="表格单元格"
+          selectionMode="multiple"
+          selectedKeys={selectedKeys}
+          orientation="horizontal"
+          size="sm"
+        >
+          {toggleButtons.map((button, index) => (
+            <Fragment key={button}>
+              {index > 0 ? <ToggleButtonGroup.Separator /> : null}
+              {button === 'merge' ? (
+                <ToolbarToggleButton
+                  id={isSplitAction ? 'split-cell' : 'merge-cells'}
+                  label={isSplitAction ? '取消合并' : '合并单元格'}
+                  icon={
+                    isSplitAction ? <TableCellsSplit size={20} /> : <TableCellsMerge size={20} />
+                  }
+                  onPress={() => {
+                    if (isSplitAction) {
+                      const splitCells = [...state.splitCells].sort((a, b) => {
+                        if (a.row !== b.row) {
+                          return b.row - a.row;
+                        }
+                        return b.col - a.col;
+                      });
+                      for (const cell of splitCells) {
+                        tableHandles?.splitCell(cell);
+                      }
+                    } else {
+                      tableHandles?.mergeCells();
+                    }
+                    refocusEditor();
+                  }}
+                />
+              ) : null}
+              {button === 'header-row' ? (
+                <ToolbarToggleButton
+                  id="table-header-row"
+                  label={state.isHeaderRow ? '取消标题行' : '设置为标题行'}
+                  icon={<PanelTop size={20} />}
+                  onPress={() => toggleHeader('row')}
+                />
+              ) : null}
+              {button === 'header-column' ? (
+                <ToolbarToggleButton
+                  id="table-header-column"
+                  label={state.isHeaderColumn ? '取消标题列' : '设置为标题列'}
+                  icon={<PanelLeft size={20} />}
+                  onPress={() => toggleHeader('column')}
+                />
+              ) : null}
+            </Fragment>
+          ))}
+        </ToggleButtonGroup>
+      ) : null}
+      <ButtonGroup size="sm" variant="ghost" aria-label="表格颜色">
+        <Popover isOpen={colorOpen} onOpenChange={setColorOpen} deferContent={false}>
+          <Popover.Trigger>
+            <Button
+              variant="ghost"
+              size="sm"
+              isIconOnly
+              className={colorOpen ? styles.toolbarButtonActive : undefined}
+              aria-label="单元格背景色"
+              onMouseDown={stopToolbarMouseDown}
+            >
+              <Paintbrush size={20} aria-hidden="true" />
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content className={styles.colorPopover} placement="bottom">
+            <Popover.Dialog>
+              <ColorPaletteContent
+                background={{
+                  color: state.backgroundColor,
+                  onChange: applyBackgroundColor,
+                }}
+                onReset={() => applyBackgroundColor('default')}
+              />
+            </Popover.Dialog>
+          </Popover.Content>
+        </Popover>
+      </ButtonGroup>
+    </>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/TextAlignButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/TextAlignButtons.tsx
@@ -1,4 +1,5 @@
 import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { getSafeTableCellSelection } from '@/components/Note/tableHandlesSafe';
 import {
   blockHasType,
   defaultProps,
@@ -7,7 +8,6 @@ import {
   type StyleSchema,
   type TableContent,
 } from '@blocknote/core';
-import { TableHandlesExtension } from '@blocknote/core/extensions';
 import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
 import { ToggleButtonGroup } from '@heroui/react';
 import { AlignCenter, AlignLeft, AlignRight } from 'lucide-react';
@@ -46,7 +46,7 @@ export function TextAlignButtons() {
       }
 
       if (selectedBlocks.length === 1 && blockHasType(firstBlock, editor, 'table')) {
-        const cellSelection = editor.getExtension(TableHandlesExtension)?.getCellSelection();
+        const cellSelection = getSafeTableCellSelection(editor);
         if (!cellSelection) {
           return undefined;
         }

--- a/src/components/Note/NoteToolbar/components/TextAlignButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/TextAlignButtons.tsx
@@ -1,0 +1,136 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import {
+  blockHasType,
+  defaultProps,
+  mapTableCell,
+  type InlineContentSchema,
+  type StyleSchema,
+  type TableContent,
+} from '@blocknote/core';
+import { TableHandlesExtension } from '@blocknote/core/extensions';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { ToggleButtonGroup } from '@heroui/react';
+import { AlignCenter, AlignLeft, AlignRight } from 'lucide-react';
+import { Fragment } from 'react';
+import { getSelectedBlocks, toBlockUpdate } from '../utils';
+import { ToolbarToggleButton } from './ToolbarButton';
+
+const textAlignButtons = [
+  { key: 'left', label: '左对齐', icon: AlignLeft },
+  { key: 'center', label: '居中对齐', icon: AlignCenter },
+  { key: 'right', label: '右对齐', icon: AlignRight },
+] as const;
+
+type TextAlignment = (typeof textAlignButtons)[number]['key'];
+
+export function TextAlignButtons() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return undefined;
+      }
+      const selectedBlocks = getSelectedBlocks(editor);
+      const firstBlock = selectedBlocks[0];
+      if (
+        blockHasType(firstBlock, editor, firstBlock.type, {
+          textAlignment: defaultProps.textAlignment,
+        })
+      ) {
+        return {
+          kind: 'blocks' as const,
+          textAlignment: firstBlock.props.textAlignment as TextAlignment,
+          blocks: selectedBlocks,
+        };
+      }
+
+      if (selectedBlocks.length === 1 && blockHasType(firstBlock, editor, 'table')) {
+        const cellSelection = editor.getExtension(TableHandlesExtension)?.getCellSelection();
+        if (!cellSelection) {
+          return undefined;
+        }
+        const tableContent = firstBlock.content as TableContent<InlineContentSchema, StyleSchema>;
+        return {
+          kind: 'table' as const,
+          textAlignment: mapTableCell(tableContent.rows[0].cells[0]).props
+            .textAlignment as TextAlignment,
+          block: firstBlock,
+          cellSelection,
+        };
+      }
+      return undefined;
+    },
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  const setTextAlignment = (alignment: TextAlignment) => {
+    editor.focus();
+    if (state.kind === 'blocks') {
+      for (const block of state.blocks) {
+        if (
+          blockHasType(block, editor, block.type, {
+            textAlignment: defaultProps.textAlignment,
+          })
+        ) {
+          editor.updateBlock(block, toBlockUpdate({ props: { textAlignment: alignment } }));
+        }
+      }
+      return;
+    }
+
+    const tableContent = state.block.content as TableContent<InlineContentSchema, StyleSchema>;
+    const rows = tableContent.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => mapTableCell(cell)),
+    }));
+    for (const cell of state.cellSelection.cells) {
+      const targetCell = rows[cell.row]?.cells[cell.col];
+      if (targetCell) {
+        targetCell.props.textAlignment = alignment;
+      }
+    }
+    editor.updateBlock(
+      state.block,
+      toBlockUpdate({
+        type: 'table',
+        content: {
+          ...tableContent,
+          type: 'tableContent',
+          rows,
+        },
+      })
+    );
+    editor.setTextCursorPosition(state.block);
+  };
+
+  return (
+    <ToggleButtonGroup
+      aria-label="文本对齐"
+      selectionMode="single"
+      selectedKeys={new Set([state.textAlignment])}
+      onSelectionChange={(keys) => {
+        const [key] = [...keys];
+        if (key != null) {
+          setTextAlignment(String(key) as TextAlignment);
+        }
+      }}
+      orientation="horizontal"
+      size="sm"
+      disallowEmptySelection
+    >
+      {textAlignButtons.map((item, index) => {
+        const Icon = item.icon;
+        return (
+          <Fragment key={item.key}>
+            {index > 0 ? <ToggleButtonGroup.Separator /> : null}
+            <ToolbarToggleButton id={item.key} label={item.label} icon={<Icon size={20} />} />
+          </Fragment>
+        );
+      })}
+    </ToggleButtonGroup>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/TextStyleButtons.tsx
+++ b/src/components/Note/NoteToolbar/components/TextStyleButtons.tsx
@@ -1,0 +1,92 @@
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+import { ToggleButtonGroup } from '@heroui/react';
+import { Bold, Code, Italic, Strikethrough, Underline } from 'lucide-react';
+import { Fragment } from 'react';
+import {
+  basicStyleExists,
+  blockHasInlineContent,
+  getSelectedBlocks,
+  toStyleUpdate,
+} from '../utils';
+import { ToolbarToggleButton } from './ToolbarButton';
+
+const textStyleButtons = [
+  { key: 'bold', label: '加粗', icon: Bold, strokeWidth: 2.5 },
+  { key: 'strike', label: '删除线', icon: Strikethrough },
+  { key: 'italic', label: '斜体', icon: Italic },
+  { key: 'underline', label: '下划线', icon: Underline },
+  { key: 'code', label: '行内代码', icon: Code },
+] as const;
+
+type BasicTextStyle = (typeof textStyleButtons)[number]['key'];
+
+export function TextStyleButtons() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable || !getSelectedBlocks(editor).find(blockHasInlineContent)) {
+        return undefined;
+      }
+      const items = textStyleButtons.filter((item) => basicStyleExists(editor, item.key));
+      if (items.length === 0) {
+        return undefined;
+      }
+      const activeStyles = editor.getActiveStyles();
+      return {
+        items,
+        selectedKeys: new Set<BasicTextStyle>(
+          items.filter((item) => item.key in activeStyles).map((item) => item.key)
+        ),
+      };
+    },
+  });
+
+  if (!state) {
+    return null;
+  }
+
+  const toggleStyle = (style: BasicTextStyle) => {
+    editor.focus();
+    editor.toggleStyles(toStyleUpdate({ [style]: true }));
+  };
+
+  return (
+    <ToggleButtonGroup
+      aria-label="文字样式"
+      selectionMode="multiple"
+      selectedKeys={state.selectedKeys}
+      onSelectionChange={(keys) => {
+        const nextKeys = new Set([...keys].map(String));
+        const changedItem = state.items.find(
+          (item) => state.selectedKeys.has(item.key) !== nextKeys.has(item.key)
+        );
+        if (changedItem) {
+          toggleStyle(changedItem.key);
+        }
+      }}
+      orientation="horizontal"
+      size="sm"
+    >
+      {state.items.map((item, index) => {
+        const Icon = item.icon;
+        return (
+          <Fragment key={item.key}>
+            {index > 0 ? <ToggleButtonGroup.Separator /> : null}
+            <ToolbarToggleButton
+              id={item.key}
+              label={item.label}
+              icon={
+                <Icon
+                  size={20}
+                  strokeWidth={'strokeWidth' in item ? item.strokeWidth : undefined}
+                />
+              }
+            />
+          </Fragment>
+        );
+      })}
+    </ToggleButtonGroup>
+  );
+}

--- a/src/components/Note/NoteToolbar/components/ToolbarButton.tsx
+++ b/src/components/Note/NoteToolbar/components/ToolbarButton.tsx
@@ -1,0 +1,72 @@
+import { Button, ToggleButton } from '@heroui/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { stopToolbarMouseDown } from '../utils';
+
+export type ButtonGroupChildProps = Pick<ComponentProps<typeof Button>, '__button_group_child'>;
+
+interface ToolbarButtonProps extends ButtonGroupChildProps {
+  label: string;
+  icon: ReactNode;
+  isDisabled?: boolean;
+  className?: string;
+  onMouseDownCapture?: ComponentProps<typeof Button>['onMouseDownCapture'];
+  onPress?: () => void;
+}
+
+export function ToolbarButton({
+  label,
+  icon,
+  isDisabled,
+  className,
+  onMouseDownCapture,
+  onPress,
+  ...buttonGroupProps
+}: ToolbarButtonProps) {
+  return (
+    <Button
+      {...buttonGroupProps}
+      variant="ghost"
+      size="sm"
+      isIconOnly
+      isDisabled={isDisabled}
+      aria-label={label}
+      className={className}
+      onMouseDownCapture={onMouseDownCapture}
+      onMouseDown={stopToolbarMouseDown}
+      onPress={onPress}
+    >
+      {icon}
+    </Button>
+  );
+}
+
+interface ToolbarToggleButtonProps {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  isDisabled?: boolean;
+  onPress?: () => void;
+}
+
+export function ToolbarToggleButton({
+  id,
+  label,
+  icon,
+  isDisabled,
+  onPress,
+}: ToolbarToggleButtonProps) {
+  return (
+    <ToggleButton
+      id={id}
+      variant="ghost"
+      size="sm"
+      isIconOnly
+      isDisabled={isDisabled}
+      aria-label={label}
+      onMouseDown={stopToolbarMouseDown}
+      onPress={onPress}
+    >
+      {icon}
+    </ToggleButton>
+  );
+}

--- a/src/components/Note/NoteToolbar/index.tsx
+++ b/src/components/Note/NoteToolbar/index.tsx
@@ -1,35 +1,155 @@
-import { useBlockNoteEditor } from '@blocknote/react';
-import { ButtonGroup, Toolbar } from '@heroui/react';
-import { MessageSquarePlus, Sparkles } from 'lucide-react';
-
+import { blockNoteSchema } from '@/components/Note/CustomBlockNote/blockNoteSchema';
 import { shouldHideFormattingToolbarForMathBlock } from '@/components/Note/CustomBlockNote/comments/core/isCommentableSelection';
 import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
+import {
+  blockMatchesBlockTypeItem,
+  getAvailableBlockTypeItems,
+} from '@/components/Note/NoteEditorMenus/blockTypes';
+import {
+  useTableRailSelectionState,
+  type TableRailSelectionOrientation,
+} from '@/components/Note/NoteTableHandles/railSelectionState';
+import { blockHasType } from '@blocknote/core';
+import { FormattingToolbarExtension } from '@blocknote/core/extensions';
+import {
+  GenericPopover,
+  useBlockNoteEditor,
+  useEditorState,
+  useExtension,
+  useExtensionState,
+  type GenericPopoverReference,
+} from '@blocknote/react';
+import { ButtonGroup, Separator, Toolbar } from '@heroui/react';
+import { MessageSquarePlus, Sparkles } from 'lucide-react';
+import { useMemo, type ComponentProps } from 'react';
 import { BlockTypeMenu } from './components/BlockTypeMenu';
 import { ColorMenu } from './components/ColorMenu';
 import { FileCaptionToolbarButton } from './components/FileButtons';
 import { CreateLinkToolbarButton } from './components/LinkButton';
 import { NestButtons } from './components/NestButtons';
+import { TableCellButtons } from './components/TableCellButtons';
 import { TextAlignButtons } from './components/TextAlignButtons';
 import { TextStyleButtons } from './components/TextStyleButtons';
 import { ToolbarButton } from './components/ToolbarButton';
 import type { NoteToolbarProps } from './index.type';
 import styles from './style.module.less';
 import { useFloatingToolbarState } from './useFloatingToolbarState';
-import { stopToolbarMouseDown } from './utils';
+import { getSelectedBlocks, stopToolbarMouseDown } from './utils';
 
-function NoteToolbar({
+const getTableRailToolbarPlacement = (
+  orientation: TableRailSelectionOrientation
+): 'top' | 'right' => (orientation === 'column' ? 'top' : 'right');
+
+const toDOMRect = (rect: { height: number; width: number; x: number; y: number }) =>
+  new DOMRect(rect.x, rect.y, rect.width, rect.height);
+
+function ToolbarSeparator() {
+  return <Separator orientation="vertical" className={styles.toolbarSeparator} />;
+}
+
+function useBlockTypeFileGroupVisible() {
+  const editor = useBlockNoteEditor(blockNoteSchema);
+
+  return useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return false;
+      }
+
+      const selectedBlocks = getSelectedBlocks(editor);
+      const firstBlock = selectedBlocks[0];
+      const { primaryItems, headingItems } = getAvailableBlockTypeItems(editor);
+      const blockTypeVisible = [...primaryItems, ...headingItems].some((item) =>
+        blockMatchesBlockTypeItem(firstBlock, item)
+      );
+      const fileCaptionVisible =
+        selectedBlocks.length === 1 &&
+        blockHasType(selectedBlocks[0], editor, selectedBlocks[0].type, {
+          caption: 'string',
+          url: 'string',
+        });
+
+      return blockTypeVisible || fileCaptionVisible;
+    },
+  });
+}
+
+function CustomFormattingToolbar({
   onAskAi,
   showAddComment = false,
   onRememberPendingCommentReference,
 }: NoteToolbarProps) {
   const readOnly = useNoteEditorReadOnlyContext();
   const editor = useBlockNoteEditor();
-  const toolbarState = useFloatingToolbarState(editor);
+  const showBlockTypeFileGroup = useBlockTypeFileGroupVisible();
   const commentsExtension = editor.getExtension('comments') as
     | { startPendingComment?: () => void }
     | undefined;
 
-  if (!toolbarState.visible || shouldHideFormattingToolbarForMathBlock(editor)) {
+  return (
+    <Toolbar
+      aria-label="格式工具栏"
+      isAttached
+      className={styles.toolbar}
+      onMouseDown={stopToolbarMouseDown}
+    >
+      {!readOnly ? (
+        <>
+          <TableCellButtons />
+          {showBlockTypeFileGroup ? (
+            <>
+              <ToolbarSeparator />
+              <ButtonGroup size="sm" variant="ghost" aria-label="块类型和文件">
+                <BlockTypeMenu />
+                <FileCaptionToolbarButton />
+              </ButtonGroup>
+            </>
+          ) : null}
+          <ToolbarSeparator />
+          <TextStyleButtons />
+          <ToolbarSeparator />
+          <TextAlignButtons />
+          <ToolbarSeparator />
+          <ColorMenu />
+          <ToolbarSeparator />
+          <NestButtons />
+          <ToolbarSeparator />
+          <CreateLinkToolbarButton />
+          <ToolbarSeparator />
+        </>
+      ) : null}
+      <ButtonGroup size="sm" variant="ghost" aria-label="批注和 AI">
+        {showAddComment && commentsExtension?.startPendingComment ? (
+          <ToolbarButton
+            label="添加批注"
+            icon={<MessageSquarePlus size={20} />}
+            onMouseDownCapture={onRememberPendingCommentReference}
+            onPress={() => commentsExtension.startPendingComment?.()}
+          />
+        ) : null}
+        <ToolbarButton label="问 AI" icon={<Sparkles size={20} />} onPress={onAskAi} />
+      </ButtonGroup>
+    </Toolbar>
+  );
+}
+
+type TextSelectionFormattingToolbarProps = NoteToolbarProps & {
+  hidden: boolean;
+};
+
+function TextSelectionFormattingToolbar({
+  hidden,
+  ...toolbarProps
+}: TextSelectionFormattingToolbarProps) {
+  const editor = useBlockNoteEditor();
+  const toolbarState = useFloatingToolbarState(editor);
+
+  if (
+    hidden ||
+    !toolbarState.visible ||
+    shouldHideFormattingToolbarForMathBlock(editor)
+  ) {
     return null;
   }
 
@@ -41,38 +161,77 @@ function NoteToolbar({
         top: toolbarState.top,
       }}
     >
-      <Toolbar
-        aria-label="格式工具栏"
-        isAttached
-        className={styles.toolbar}
-        onMouseDown={stopToolbarMouseDown}
-      >
-        {!readOnly ? (
-          <>
-            <ButtonGroup size="sm" variant="ghost" aria-label="块类型和文件">
-              <BlockTypeMenu />
-              <FileCaptionToolbarButton />
-            </ButtonGroup>
-            <TextStyleButtons />
-            <TextAlignButtons />
-            <ColorMenu />
-            <NestButtons />
-            <CreateLinkToolbarButton />
-          </>
-        ) : null}
-        <ButtonGroup size="sm" variant="ghost" aria-label="批注和 AI">
-          {showAddComment && commentsExtension?.startPendingComment ? (
-            <ToolbarButton
-              label="添加批注"
-              icon={<MessageSquarePlus size={20} />}
-              onMouseDownCapture={onRememberPendingCommentReference}
-              onPress={() => commentsExtension.startPendingComment?.()}
-            />
-          ) : null}
-          <ToolbarButton label="问 AI" icon={<Sparkles size={20} />} onPress={onAskAi} />
-        </ButtonGroup>
-      </Toolbar>
+      <CustomFormattingToolbar {...toolbarProps} />
     </div>
+  );
+}
+
+type TableRailFormattingToolbarProps = NoteToolbarProps & {
+  tableRailSelection: ReturnType<typeof useTableRailSelectionState>;
+};
+
+function TableRailFormattingToolbar({
+  tableRailSelection,
+  ...toolbarProps
+}: TableRailFormattingToolbarProps) {
+  const editor = useBlockNoteEditor();
+  const formattingToolbar = useExtension(FormattingToolbarExtension, { editor });
+  const show = useExtensionState(FormattingToolbarExtension, { editor });
+  const reference = useMemo<GenericPopoverReference | undefined>(() => {
+    if (!tableRailSelection.rect) {
+      return undefined;
+    }
+    const element = editor.domElement?.firstElementChild ?? undefined;
+    const getBoundingClientRect = () => toDOMRect(tableRailSelection.rect!);
+
+    return element
+      ? { element, getBoundingClientRect, cacheMountedBoundingClientRect: false }
+      : { element: undefined, getBoundingClientRect };
+  }, [editor.domElement, tableRailSelection.rect]);
+  const useFloatingOptions = useMemo<ComponentProps<typeof GenericPopover>['useFloatingOptions']>(
+    () => ({
+      onOpenChange: (open, _event, reason) => {
+        formattingToolbar.store.setState(open);
+        if (reason === 'escape-key') {
+          editor.focus();
+        }
+      },
+      open: show,
+      placement:
+        tableRailSelection.orientation === null
+          ? 'top'
+          : getTableRailToolbarPlacement(tableRailSelection.orientation),
+    }),
+    [editor, formattingToolbar.store, show, tableRailSelection.orientation]
+  );
+
+  if (!tableRailSelection.orientation || !reference) {
+    return null;
+  }
+
+  return (
+    <GenericPopover
+      reference={reference}
+      useFloatingOptions={useFloatingOptions}
+      focusManagerProps={{ disabled: true }}
+      elementProps={{ className: styles.floatingLayer, style: { zIndex: 120 } }}
+    >
+      {show ? <CustomFormattingToolbar {...toolbarProps} /> : null}
+    </GenericPopover>
+  );
+}
+
+function NoteToolbar(props: NoteToolbarProps) {
+  const tableRailSelection = useTableRailSelectionState();
+
+  return (
+    <>
+      <TextSelectionFormattingToolbar
+        {...props}
+        hidden={tableRailSelection.orientation !== null}
+      />
+      <TableRailFormattingToolbar {...props} tableRailSelection={tableRailSelection} />
+    </>
   );
 }
 

--- a/src/components/Note/NoteToolbar/index.tsx
+++ b/src/components/Note/NoteToolbar/index.tsx
@@ -1,25 +1,21 @@
-import {
-  AddCommentButton,
-  BasicTextStyleButton,
-  BlockTypeSelect,
-  ColorStyleButton,
-  CreateLinkButton,
-  FileCaptionButton,
-  FileReplaceButton,
-  FormattingToolbar,
-  NestBlockButton,
-  TextAlignButton,
-  UnnestBlockButton,
-  useBlockNoteEditor,
-} from '@blocknote/react';
-import { Button } from '@heroui/react';
-import { Sparkles } from 'lucide-react';
+import { useBlockNoteEditor } from '@blocknote/react';
+import { ButtonGroup, Toolbar } from '@heroui/react';
+import { MessageSquarePlus, Sparkles } from 'lucide-react';
 
 import { shouldHideFormattingToolbarForMathBlock } from '@/components/Note/CustomBlockNote/comments/core/isCommentableSelection';
 import { useNoteEditorReadOnlyContext } from '@/components/Note/CustomBlockNote/editorReadOnly';
+import { BlockTypeMenu } from './components/BlockTypeMenu';
+import { ColorMenu } from './components/ColorMenu';
+import { FileCaptionToolbarButton } from './components/FileButtons';
+import { CreateLinkToolbarButton } from './components/LinkButton';
+import { NestButtons } from './components/NestButtons';
+import { TextAlignButtons } from './components/TextAlignButtons';
+import { TextStyleButtons } from './components/TextStyleButtons';
+import { ToolbarButton } from './components/ToolbarButton';
 import type { NoteToolbarProps } from './index.type';
 import styles from './style.module.less';
 import { useFloatingToolbarState } from './useFloatingToolbarState';
+import { stopToolbarMouseDown } from './utils';
 
 function NoteToolbar({
   onAskAi,
@@ -29,6 +25,9 @@ function NoteToolbar({
   const readOnly = useNoteEditorReadOnlyContext();
   const editor = useBlockNoteEditor();
   const toolbarState = useFloatingToolbarState(editor);
+  const commentsExtension = editor.getExtension('comments') as
+    | { startPendingComment?: () => void }
+    | undefined;
 
   if (!toolbarState.visible || shouldHideFormattingToolbarForMathBlock(editor)) {
     return null;
@@ -42,44 +41,37 @@ function NoteToolbar({
         top: toolbarState.top,
       }}
     >
-      <FormattingToolbar>
-        <Button
-          variant="primary"
-          size="sm"
-          className={styles.askAiBtn}
-          onMouseDown={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-          onPress={onAskAi}
-        >
-          <Sparkles size={14} aria-hidden="true" />问 AI
-        </Button>
-        {showAddComment ? (
-          <span onMouseDownCapture={onRememberPendingCommentReference}>
-            <AddCommentButton key="addCommentButton" />
-          </span>
-        ) : null}
+      <Toolbar
+        aria-label="格式工具栏"
+        isAttached
+        className={styles.toolbar}
+        onMouseDown={stopToolbarMouseDown}
+      >
         {!readOnly ? (
           <>
-            <BlockTypeSelect key="blockTypeSelect" />
-            <FileCaptionButton key="fileCaptionButton" />
-            <FileReplaceButton key="replaceFileButton" />
-            <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />
-            <BasicTextStyleButton basicTextStyle="italic" key="italicStyleButton" />
-            <BasicTextStyleButton basicTextStyle="underline" key="underlineStyleButton" />
-            <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
-            <BasicTextStyleButton basicTextStyle="code" key="codeStyleButton" />
-            <TextAlignButton textAlignment="left" key="textAlignLeftButton" />
-            <TextAlignButton textAlignment="center" key="textAlignCenterButton" />
-            <TextAlignButton textAlignment="right" key="textAlignRightButton" />
-            <ColorStyleButton key="colorStyleButton" />
-            <NestBlockButton key="nestBlockButton" />
-            <UnnestBlockButton key="unnestBlockButton" />
-            <CreateLinkButton key="createLinkButton" />
+            <ButtonGroup size="sm" variant="ghost" aria-label="块类型和文件">
+              <BlockTypeMenu />
+              <FileCaptionToolbarButton />
+            </ButtonGroup>
+            <TextStyleButtons />
+            <TextAlignButtons />
+            <ColorMenu />
+            <NestButtons />
+            <CreateLinkToolbarButton />
           </>
         ) : null}
-      </FormattingToolbar>
+        <ButtonGroup size="sm" variant="ghost" aria-label="批注和 AI">
+          {showAddComment && commentsExtension?.startPendingComment ? (
+            <ToolbarButton
+              label="添加批注"
+              icon={<MessageSquarePlus size={20} />}
+              onMouseDownCapture={onRememberPendingCommentReference}
+              onPress={() => commentsExtension.startPendingComment?.()}
+            />
+          ) : null}
+          <ToolbarButton label="问 AI" icon={<Sparkles size={20} />} onPress={onAskAi} />
+        </ButtonGroup>
+      </Toolbar>
     </div>
   );
 }

--- a/src/components/Note/NoteToolbar/style.module.less
+++ b/src/components/Note/NoteToolbar/style.module.less
@@ -23,6 +23,11 @@
   border: 1px solid var(--border-light);
   background: var(--overlay);
   color: var(--overlay-foreground);
+  gap: 0;
+}
+
+.floatingLayer {
+  z-index: var(--note-editor-toolbar-layer, 120);
 }
 
 .toolbar :global([data-slot='button-group-separator']),
@@ -33,6 +38,20 @@
   align-self: center;
   background: var(--separator);
   opacity: 1;
+}
+
+.toolbarSeparator {
+  width: 1px;
+  height: calc(var(--control-height-sm) - var(--space-sm));
+  align-self: center;
+  margin-inline: var(--space-2xs);
+  background: var(--separator);
+}
+
+.toolbarSeparator:first-child,
+.toolbarSeparator:last-child,
+.toolbarSeparator + .toolbarSeparator {
+  display: none;
 }
 
 .toolbarButtonActive {

--- a/src/components/Note/NoteToolbar/style.module.less
+++ b/src/components/Note/NoteToolbar/style.module.less
@@ -4,10 +4,287 @@
   transform: translate(-50%, -100%);
 }
 
-.askAiBtn {
+.toolbar,
+.blockTypeMenuPopover,
+.colorPopover,
+.formPopover {
+  --note-toolbar-trigger-padding-inline: var(--space-xs);
+  --note-toolbar-trigger-gap: var(--space-2xs);
+  --note-toolbar-trigger-icon-size: calc(var(--control-height-sm) - var(--space-2xs));
+  --note-toolbar-menu-padding: var(--space-xs);
+  --note-toolbar-menu-gap: var(--space-2xs);
+  --note-toolbar-menu-width: 18rem;
+  --note-toolbar-menu-max-height: min(32.5rem, calc(100vh - var(--space-2xl) - var(--space-xl) - var(--space-lg)));
+  --note-toolbar-menu-icon-column: var(--control-height);
+  --note-toolbar-menu-trailing-column: calc(var(--space-md) + var(--space-2xs));
+  --note-toolbar-swatch-size: var(--space-xl);
+  --note-toolbar-swatch-columns: 10;
+}
+
+.toolbar {
+  border: 1px solid var(--border-light);
+  background: var(--overlay);
+  color: var(--overlay-foreground);
+}
+
+.toolbar :global([data-slot='button-group-separator']),
+.toolbar :global([data-slot='toggle-button-group-separator']) {
+  position: static;
+  width: 1px;
+  height: calc(var(--control-height-sm) - var(--space-sm));
   align-self: center;
-  margin-left: var(--space-xs);
-  margin-right: var(--space-xs);
-  margin-top: var(--space-2xs);
-  margin-bottom: var(--space-2xs);
+  background: var(--separator);
+  opacity: 1;
+}
+
+.toolbarButtonActive {
+  background: var(--accent-soft);
+  color: var(--accent-soft-foreground);
+}
+
+.blockTypeTrigger {
+  min-width: calc(var(--control-height) + var(--space-md));
+  padding-inline: var(--note-toolbar-trigger-padding-inline);
+  gap: var(--note-toolbar-trigger-gap);
+  color: var(--overlay-foreground);
+}
+
+.blockTypeTriggerIcon {
+  width: var(--note-toolbar-trigger-icon-size);
+  height: var(--note-toolbar-trigger-icon-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.blockTypeMenuPopover,
+.colorPopover,
+.formPopover {
+  padding: 0;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  background: var(--overlay);
+  box-shadow: var(--overlay-shadow);
+}
+
+.blockTypeMenu {
+  width: var(--note-toolbar-menu-width);
+  max-height: var(--note-toolbar-menu-max-height);
+  display: flex;
+  flex-direction: column;
+  gap: var(--note-toolbar-menu-gap);
+  overflow-y: auto;
+  padding: var(--note-toolbar-menu-padding);
+}
+
+.blockTypeMenuItem {
+  width: 100%;
+  min-height: var(--control-height);
+  display: grid;
+  grid-template-columns: var(--note-toolbar-menu-icon-column) minmax(0, 1fr) var(--note-toolbar-menu-trailing-column);
+  align-items: center;
+  gap: var(--space-xs);
+  padding: 0 var(--space-xs);
+  border-radius: var(--radius-md);
+  color: var(--overlay-foreground);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.blockTypeMenuItem:hover,
+.blockTypeMenuItem[data-hovered],
+.blockTypeMenuItem[data-focused],
+.blockTypeMenuItem[data-selected],
+.blockTypeMenuItemActive {
+  background: var(--surface-secondary);
+}
+
+.blockTypeMenuIcon {
+  width: var(--control-height-sm);
+  height: var(--control-height-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary);
+}
+
+.blockTypeMenuLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.blockTypeMenuCheck {
+  width: var(--line-height-xs);
+  height: var(--line-height-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: end;
+  color: var(--primary);
+}
+
+.colorTrigger {
+  min-width: calc(var(--control-height) + var(--space-sm));
+  padding-inline: var(--note-toolbar-trigger-padding-inline);
+  gap: var(--note-toolbar-trigger-gap);
+  color: var(--overlay-foreground);
+}
+
+.colorPanel {
+  width: max-content;
+  padding: var(--space-md);
+}
+
+.colorSection + .colorSection {
+  margin-top: var(--space-sm);
+}
+
+.colorSectionTitle {
+  margin-bottom: var(--space-xs);
+  color: var(--muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-sm);
+}
+
+.colorSwatchPicker {
+  display: grid;
+  grid-template-columns: repeat(var(--note-toolbar-swatch-columns), var(--note-toolbar-swatch-size));
+  gap: var(--space-xs);
+}
+
+.colorSwatchItem {
+  width: var(--note-toolbar-swatch-size);
+  height: var(--note-toolbar-swatch-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  cursor: pointer;
+}
+
+.colorSwatchItem:hover,
+.colorSwatchItem[data-hovered],
+.colorSwatchSelected {
+  border-color: var(--primary);
+}
+
+.colorSwatchSelected {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 22%, transparent);
+}
+
+.colorTextPreview {
+  flex-shrink: 0;
+}
+
+.colorBackgroundPreview {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: var(--radius-sm);
+}
+
+.backgroundDefault {
+  background:
+    linear-gradient(
+      135deg,
+      transparent 48%,
+      var(--primary) 49%,
+      var(--primary) 51%,
+      transparent 52%
+    ),
+    var(--surface);
+}
+
+.textDefault {
+  color: var(--overlay-foreground);
+}
+
+.textGray {
+  color: #8a8f98;
+}
+
+.textBrown {
+  color: #8b5e3c;
+}
+
+.textRed {
+  color: #ef4444;
+}
+
+.textOrange {
+  color: #f97316;
+}
+
+.textYellow {
+  color: #eab308;
+}
+
+.textGreen {
+  color: #22c55e;
+}
+
+.textBlue {
+  color: #3b82f6;
+}
+
+.textPurple {
+  color: #7c3aed;
+}
+
+.textPink {
+  color: #ec4899;
+}
+
+.backgroundGray {
+  background: #e5e7eb;
+}
+
+.backgroundBrown {
+  background: #ead7c2;
+}
+
+.backgroundRed {
+  background: #fecaca;
+}
+
+.backgroundOrange {
+  background: #fed7aa;
+}
+
+.backgroundYellow {
+  background: #fef08a;
+}
+
+.backgroundGreen {
+  background: #bbf7d0;
+}
+
+.backgroundBlue {
+  background: #bfdbfe;
+}
+
+.backgroundPurple {
+  background: #ddd6fe;
+}
+
+.backgroundPink {
+  background: #fbcfe8;
+}
+
+.resetColorButton {
+  width: 100%;
+  margin-top: var(--space-md);
+}
+
+.formPanel {
+  width: min(18.75rem, calc(100vw - var(--space-xl)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
 }

--- a/src/components/Note/NoteToolbar/style.module.less
+++ b/src/components/Note/NoteToolbar/style.module.less
@@ -17,8 +17,6 @@
   --note-toolbar-menu-max-height: min(32.5rem, calc(100vh - var(--space-2xl) - var(--space-xl) - var(--space-lg)));
   --note-toolbar-menu-icon-column: var(--control-height);
   --note-toolbar-menu-trailing-column: calc(var(--space-md) + var(--space-2xs));
-  --note-toolbar-swatch-size: var(--space-xl);
-  --note-toolbar-swatch-columns: 10;
 }
 
 .toolbar {
@@ -61,10 +59,6 @@
 .colorPopover,
 .formPopover {
   padding: 0;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-lg);
-  background: var(--overlay);
-  box-shadow: var(--overlay-shadow);
 }
 
 .blockTypeMenu {
@@ -85,7 +79,6 @@
   align-items: center;
   gap: var(--space-xs);
   padding: 0 var(--space-xs);
-  border-radius: var(--radius-md);
   color: var(--overlay-foreground);
   font-size: var(--font-size-sm);
   line-height: var(--line-height-sm);
@@ -130,155 +123,6 @@
   padding-inline: var(--note-toolbar-trigger-padding-inline);
   gap: var(--note-toolbar-trigger-gap);
   color: var(--overlay-foreground);
-}
-
-.colorPanel {
-  width: max-content;
-  padding: var(--space-md);
-}
-
-.colorSection + .colorSection {
-  margin-top: var(--space-sm);
-}
-
-.colorSectionTitle {
-  margin-bottom: var(--space-xs);
-  color: var(--muted);
-  font-size: var(--font-size-sm);
-  line-height: var(--line-height-sm);
-}
-
-.colorSwatchPicker {
-  display: grid;
-  grid-template-columns: repeat(var(--note-toolbar-swatch-columns), var(--note-toolbar-swatch-size));
-  gap: var(--space-xs);
-}
-
-.colorSwatchItem {
-  width: var(--note-toolbar-swatch-size);
-  height: var(--note-toolbar-swatch-size);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
-  background: var(--surface);
-  cursor: pointer;
-}
-
-.colorSwatchItem:hover,
-.colorSwatchItem[data-hovered],
-.colorSwatchSelected {
-  border-color: var(--primary);
-}
-
-.colorSwatchSelected {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 22%, transparent);
-}
-
-.colorTextPreview {
-  flex-shrink: 0;
-}
-
-.colorBackgroundPreview {
-  width: 100%;
-  height: 100%;
-  display: block;
-  border-radius: var(--radius-sm);
-}
-
-.backgroundDefault {
-  background:
-    linear-gradient(
-      135deg,
-      transparent 48%,
-      var(--primary) 49%,
-      var(--primary) 51%,
-      transparent 52%
-    ),
-    var(--surface);
-}
-
-.textDefault {
-  color: var(--overlay-foreground);
-}
-
-.textGray {
-  color: #8a8f98;
-}
-
-.textBrown {
-  color: #8b5e3c;
-}
-
-.textRed {
-  color: #ef4444;
-}
-
-.textOrange {
-  color: #f97316;
-}
-
-.textYellow {
-  color: #eab308;
-}
-
-.textGreen {
-  color: #22c55e;
-}
-
-.textBlue {
-  color: #3b82f6;
-}
-
-.textPurple {
-  color: #7c3aed;
-}
-
-.textPink {
-  color: #ec4899;
-}
-
-.backgroundGray {
-  background: #e5e7eb;
-}
-
-.backgroundBrown {
-  background: #ead7c2;
-}
-
-.backgroundRed {
-  background: #fecaca;
-}
-
-.backgroundOrange {
-  background: #fed7aa;
-}
-
-.backgroundYellow {
-  background: #fef08a;
-}
-
-.backgroundGreen {
-  background: #bbf7d0;
-}
-
-.backgroundBlue {
-  background: #bfdbfe;
-}
-
-.backgroundPurple {
-  background: #ddd6fe;
-}
-
-.backgroundPink {
-  background: #fbcfe8;
-}
-
-.resetColorButton {
-  width: 100%;
-  margin-top: var(--space-md);
 }
 
 .formPanel {

--- a/src/components/Note/NoteToolbar/utils.ts
+++ b/src/components/Note/NoteToolbar/utils.ts
@@ -20,7 +20,11 @@ export function blockHasInlineContent(block: NoteBlock): boolean {
 }
 
 export function getSelectedBlocks(editor: CustomBlockNoteEditor): NoteBlock[] {
-  return editor.getSelection()?.blocks ?? [editor.getTextCursorPosition().block];
+  try {
+    return editor.getSelection()?.blocks ?? [editor.getTextCursorPosition().block];
+  } catch {
+    return [];
+  }
 }
 
 export function getSchemaStyleRecord(editor: CustomBlockNoteEditor) {

--- a/src/components/Note/NoteToolbar/utils.ts
+++ b/src/components/Note/NoteToolbar/utils.ts
@@ -1,0 +1,56 @@
+import type { MouseEvent as ReactMouseEvent } from 'react';
+import type { CustomBlockNoteEditor } from '../CustomBlockNote/blockNoteSchema';
+
+export type NoteBlock = ReturnType<CustomBlockNoteEditor['getTextCursorPosition']>['block'];
+export type NoteBlockUpdate = Parameters<CustomBlockNoteEditor['updateBlock']>[1];
+export type NoteStyleUpdate = Parameters<CustomBlockNoteEditor['addStyles']>[0];
+
+export function cx(...classNames: Array<string | false | null | undefined>) {
+  return classNames.filter(Boolean).join(' ');
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function stopToolbarMouseDown(event: ReactMouseEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+export function blockHasInlineContent(block: NoteBlock): boolean {
+  return block.content !== undefined;
+}
+
+export function getSelectedBlocks(editor: CustomBlockNoteEditor): NoteBlock[] {
+  return editor.getSelection()?.blocks ?? [editor.getTextCursorPosition().block];
+}
+
+export function getSchemaStyleRecord(editor: CustomBlockNoteEditor) {
+  return editor.schema.styleSchema as Record<string, { type?: unknown; propSchema?: unknown }>;
+}
+
+export function basicStyleExists(editor: CustomBlockNoteEditor, style: string): boolean {
+  const schemaStyle = getSchemaStyleRecord(editor)[style];
+  return schemaStyle?.type === style && schemaStyle.propSchema === 'boolean';
+}
+
+export function colorStyleExists(
+  editor: CustomBlockNoteEditor,
+  colorType: 'textColor' | 'backgroundColor'
+): boolean {
+  const schemaStyle = getSchemaStyleRecord(editor)[colorType];
+  return schemaStyle?.type === colorType && schemaStyle.propSchema === 'string';
+}
+
+export function toStyleUpdate(style: Record<string, string | boolean>): NoteStyleUpdate {
+  return style as NoteStyleUpdate;
+}
+
+export function toBlockUpdate(update: {
+  type?: string;
+  props?: Record<string, unknown>;
+  content?: unknown;
+}): NoteBlockUpdate {
+  return update as NoteBlockUpdate;
+}

--- a/src/components/Note/NoteToolbar/utils.ts
+++ b/src/components/Note/NoteToolbar/utils.ts
@@ -1,17 +1,14 @@
 import type { MouseEvent as ReactMouseEvent } from 'react';
 import type { CustomBlockNoteEditor } from '../CustomBlockNote/blockNoteSchema';
+import type { NoteBlock } from '../NoteEditorMenus/utils';
+export {
+  isRecord,
+  toBlockUpdate,
+  type NoteBlock,
+  type NoteBlockUpdate,
+} from '../NoteEditorMenus/utils';
 
-export type NoteBlock = ReturnType<CustomBlockNoteEditor['getTextCursorPosition']>['block'];
-export type NoteBlockUpdate = Parameters<CustomBlockNoteEditor['updateBlock']>[1];
 export type NoteStyleUpdate = Parameters<CustomBlockNoteEditor['addStyles']>[0];
-
-export function cx(...classNames: Array<string | false | null | undefined>) {
-  return classNames.filter(Boolean).join(' ');
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 export function stopToolbarMouseDown(event: ReactMouseEvent) {
   event.preventDefault();
@@ -45,12 +42,4 @@ export function colorStyleExists(
 
 export function toStyleUpdate(style: Record<string, string | boolean>): NoteStyleUpdate {
   return style as NoteStyleUpdate;
-}
-
-export function toBlockUpdate(update: {
-  type?: string;
-  props?: Record<string, unknown>;
-  content?: unknown;
-}): NoteBlockUpdate {
-  return update as NoteBlockUpdate;
 }

--- a/src/components/Note/tableHandlesSafe.ts
+++ b/src/components/Note/tableHandlesSafe.ts
@@ -1,0 +1,32 @@
+import type { CustomBlockNoteEditor } from '@/components/Note/CustomBlockNote/blockNoteSchema';
+import { TableHandlesExtension } from '@blocknote/core/extensions';
+
+type TableHandles = ReturnType<ReturnType<typeof TableHandlesExtension>>;
+
+export function hasMountedEditorView(editor: CustomBlockNoteEditor) {
+  try {
+    return Boolean(editor.prosemirrorView?.dom?.isConnected);
+  } catch {
+    return false;
+  }
+}
+
+export function getTableHandles(editor: CustomBlockNoteEditor): TableHandles | undefined {
+  if (!hasMountedEditorView(editor)) {
+    return undefined;
+  }
+
+  try {
+    return editor.getExtension(TableHandlesExtension) as TableHandles | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getSafeTableCellSelection(editor: CustomBlockNoteEditor) {
+  try {
+    return getTableHandles(editor)?.getCellSelection();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/views/workspace/note/index.tsx
+++ b/src/views/workspace/note/index.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo, useRef, useState, type CSSProperties, type ReactN
 import { Link } from 'react-router-dom';
 
 import EntryIcon from '@/components/Icons/EntryIcon';
-import ResourceActionFooter from '@/components/interact/ResourceActionFooter';
 import CustomBlockNote from '@/components/Note/CustomBlockNote';
 import { useCommentSettingsSync } from '@/components/Note/CustomBlockNote/comments';
 import type {
@@ -489,7 +488,6 @@ function NoteViewConnected({
                     />
                   ) : null}
                 </div>
-                <ResourceActionFooter resourceId={resourceId} onRateSuccess={onRefreshNoteInfo} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## 变更内容

- 将 Note 工具栏和快捷菜单迁移到统一的 HeroUI 视觉与交互实现。
- 新增自定义块类型、颜色、文字样式、对齐、缩进、链接和文件操作控件。
- 重构 Note 侧边手柄、斜杠菜单与 Table 行列手柄，补充表格单元格操作。
- 基于最新 `main` 保留批注功能，并将添加批注入口纳入新工具栏样式。
- 移除 Note workspace 中被重新引入的资源互动区。
