### PR TITLE
fix(sidebar): 统一对话空状态样式

### DIFF
--- a/src/i18n/locales/zh-CN/chat.ts
+++ b/src/i18n/locales/zh-CN/chat.ts
@@ -103,7 +103,7 @@ const zhCNChat = {
     untitled: '未命名对话',
     noTime: '暂无时间',
     loading: '加载中...',
-    empty: '暂无会话',
+    empty: '暂无对话',
     loadMore: '加载更多',
     noMore: '没有更多了',
     renameSuccess: '重命名成功',

--- a/src/layouts/_common/Sidebar/AppSidebar/AppSidebarTabs/style.module.less
+++ b/src/layouts/_common/Sidebar/AppSidebar/AppSidebarTabs/style.module.less
@@ -327,6 +327,14 @@
   }
 }
 
+.sessionEmptyState {
+  display: grid;
+  min-height: 120px;
+  place-items: center;
+  color: var(--muted);
+  font-size: var(--font-size-sm);
+}
+
 .sessionItemWithActions {
   &:hover,
   &[data-hovered],

--- a/src/layouts/_common/Sidebar/AppSidebar/SessionListGroup/index.tsx
+++ b/src/layouts/_common/Sidebar/AppSidebar/SessionListGroup/index.tsx
@@ -112,6 +112,10 @@ function SessionListGroup({ selectedKeys, refreshVersion = 0 }: SessionListGroup
     void refresh();
   }, [refresh, refreshVersion]);
 
+  if (!sessionListLoading && sessionItems.length === 0) {
+    return <div className={styles.sessionEmptyState}>{t('session.empty')}</div>;
+  }
+
   return (
     <ListBox
       aria-label={t('session.listAria')}
@@ -132,33 +136,17 @@ function SessionListGroup({ selectedKeys, refreshVersion = 0 }: SessionListGroup
           </ListBoxItem>
         ) : (
           <>
-            {sessionItems.length === 0 ? (
+            {sessionItems.map((session) => (
               <ListBoxItem
-                key="empty-normal-session"
-                id="empty-normal-session"
-                textValue={t('session.empty')}
-                isDisabled
-                className={styles.sessionItem}
+                key={session.id}
+                id={`session-${session.id}`}
+                textValue={session.title || t('session.untitled')}
+                className={cn(styles.sessionItem, styles.sessionItemWithActions)}
+                onPress={() => selectSession(session)}
               >
-                {t('session.empty')}
+                <SessionMenuItem session={session} onUpdated={refresh} onDeleted={handleDeleted} />
               </ListBoxItem>
-            ) : (
-              sessionItems.map((session) => (
-                <ListBoxItem
-                  key={session.id}
-                  id={`session-${session.id}`}
-                  textValue={session.title || t('session.untitled')}
-                  className={cn(styles.sessionItem, styles.sessionItemWithActions)}
-                  onPress={() => selectSession(session)}
-                >
-                  <SessionMenuItem
-                    session={session}
-                    onUpdated={refresh}
-                    onDeleted={handleDeleted}
-                  />
-                </ListBoxItem>
-              ))
-            )}
+            ))}
             {(hasMoreSessions || loadingMoreSessions) && (
               <ListBoxItem
                 key="session-load-more"


### PR DESCRIPTION
## 改动内容

- 将对话侧栏空状态文案从“暂无会话”调整为“暂无对话”
- 将对话空状态从禁用的 `ListBoxItem` 改为普通状态容器
- 对齐课程空状态的居中布局、文字颜色、字号和字重

## 原因

对话空状态原先继承会话列表的中等字重，并受到 HeroUI 禁用项颜色和透明度影响，导致视觉效果与课程侧栏“暂无课程”不一致。

## 影响

仅影响对话侧栏无历史会话时的空状态展示，不修改会话加载、选择、删除或分页逻辑。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- 本地 Vite 预览确认文案及视觉样式
