### PR TITLE
fix(sidebar): 统一云盘切换菜单图标

### DIFF
--- a/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/SidebarDriveScopeSwitcher.tsx
+++ b/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/SidebarDriveScopeSwitcher.tsx
@@ -6,7 +6,7 @@ import type { Group } from '@/domains/Group';
 import { useApi } from '@/hooks/useApi';
 import { useSidebarDriveScopeStore } from '@/layouts/_common/Sidebar/DriveSidebar/_store/useSidebarDriveScopeStore';
 import { Dropdown, Header, Label } from '@heroui/react';
-import { ChevronsUpDown, HardDrive, UsersRound } from 'lucide-react';
+import { ChevronsUpDown, HardDrive } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -84,7 +84,7 @@ function SidebarDriveScopeSwitcher() {
                 id={group.groupId}
                 textValue={group.groupName || t('navigator.unnamedGroup')}
               >
-                <UsersRound size={15} aria-hidden="true" />
+                <HardDrive size={15} aria-hidden="true" />
                 <Label>{group.groupName || t('navigator.unnamedGroup')}</Label>
                 <Dropdown.ItemIndicator type="dot" />
               </Dropdown.Item>


### PR DESCRIPTION
## 修改内容

- 将“切换云盘”悬浮菜单中的小组图标改为硬盘图标
- 使小组云盘条目与个人云盘条目使用一致的图标样式

## 原因

此前个人云盘使用硬盘图标，而小组云盘使用用户组图标，视觉语义不一致。

## 影响

仅调整切换云盘菜单的小组条目图标，不改变云盘切换逻辑或其他界面。

## 验证

- 定向 ESLint 检查
- `pnpm typecheck`
