### PR TITLE
fix(sidebar): 统一我的云盘文案

### DIFF
--- a/src/i18n/locales/en-US/drive.ts
+++ b/src/i18n/locales/en-US/drive.ts
@@ -32,6 +32,7 @@ const enUSDrive = {
     empty: 'No content',
   },
   sidebar: {
+    personalDrive: 'My Drive',
     createIn: 'Create in "{{name}}"',
     collapseAll: 'Collapse all',
     renameNode: 'Rename {{name}}',

--- a/src/i18n/locales/zh-CN/drive.ts
+++ b/src/i18n/locales/zh-CN/drive.ts
@@ -32,6 +32,7 @@ const zhCNDrive = {
     empty: '暂无内容',
   },
   sidebar: {
+    personalDrive: '我的云盘',
     createIn: '在「{{name}}」中新建',
     collapseAll: '折叠全部',
     renameNode: '重命名 {{name}}',

--- a/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/SidebarDriveScopeSwitcher.tsx
+++ b/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/SidebarDriveScopeSwitcher.tsx
@@ -73,9 +73,9 @@ function SidebarDriveScopeSwitcher() {
         >
           <Dropdown.Section>
             <Header>{t('sidebar.switchDrive')}</Header>
-            <Dropdown.Item id={PERSONAL_SCOPE_KEY} textValue={t('navigator.personalDrive')}>
+            <Dropdown.Item id={PERSONAL_SCOPE_KEY} textValue={t('sidebar.personalDrive')}>
               <HardDrive size={15} aria-hidden="true" />
-              <Label>{t('navigator.personalDrive')}</Label>
+              <Label>{t('sidebar.personalDrive')}</Label>
               <Dropdown.ItemIndicator type="dot" />
             </Dropdown.Item>
             {groups.map((group) => (

--- a/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/index.tsx
+++ b/src/layouts/_common/Sidebar/DriveSidebar/_components/SidebarDrive/index.tsx
@@ -75,7 +75,7 @@ function SidebarDrive() {
     ? groupBaseInfo && groupBaseInfo.groupId === groupId
       ? groupBaseInfo.groupName || undefined
       : undefined
-    : t('navigator.personalDrive');
+    : t('sidebar.personalDrive');
 
   const resolveContainerMountTagId = (node: RootNode | FolderNode): string | undefined => {
     if (node.type === 'folder') return node.tagId;


### PR DESCRIPTION
## 修改内容

- 将侧栏“切换云盘”菜单中的“个人云盘”改为“我的云盘”
- 将切换到个人云盘后显示的小标题改为“我的云盘”
- 英文界面同步显示为 “My Drive”

## 实现范围

新增侧栏专用国际化文案键，仅供云盘切换菜单和切换后标题使用。“从个人云盘添加”等其他业务语境仍保留原文案。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- pre-push checks
